### PR TITLE
Add Telegram client library (libtd)

### DIFF
--- a/packages/libtd/build.sh
+++ b/packages/libtd/build.sh
@@ -1,0 +1,17 @@
+TERMUX_PKG_HOMEPAGE=https://core.telegram.org/tdlib/
+TERMUX_PKG_DESCRIPTION="Library for building Telegram clients"
+TERMUX_PKG_LICENSE="BSL-1.0"
+TERMUX_PKG_VERSION=1.6.0
+TERMUX_PKG_REVISION=1
+TERMUX_PKG_SRCURL=https://github.com/tdlib/td/archive/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=9dce57a96f9d4bac8f99aab13ef5cbf6fed04b234a5d22dfa7ef7dce06ea43f8
+TERMUX_PKG_DEPENDS="cmake, readline, openssl (>= 1.1.1), zlib, gperf"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="-DCMAKE_BUILD_TYPE=Release"
+TERMUX_CMAKE_BUILD="Unix Makefiles"
+TERMUX_PKG_HOSTBUILD=true
+
+termux_step_host_build() {
+        termux_setup_cmake
+        cmake "-DCMAKE_BUILD_TYPE=Release" "$TERMUX_PKG_SRCDIR"
+        cmake --build . --target prepare_cross_compiling
+}

--- a/packages/libtd/build.sh
+++ b/packages/libtd/build.sh
@@ -5,9 +5,7 @@ TERMUX_PKG_VERSION=1.6.0
 TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/tdlib/td/archive/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=9dce57a96f9d4bac8f99aab13ef5cbf6fed04b234a5d22dfa7ef7dce06ea43f8
-TERMUX_PKG_DEPENDS="cmake, readline, openssl (>= 1.1.1), zlib, gperf"
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="-DCMAKE_BUILD_TYPE=Release"
-TERMUX_CMAKE_BUILD="Unix Makefiles"
+TERMUX_PKG_DEPENDS="readline, openssl (>= 1.1.1), zlib"
 TERMUX_PKG_HOSTBUILD=true
 
 termux_step_host_build() {


### PR DESCRIPTION
Package is verified to build telegas telega-server for using Telegram from within emacs on termux.