### PR TITLE
Add samba

### DIFF
--- a/packages/samba/0001-The-great-tmp-path-replacement.patch
+++ b/packages/samba/0001-The-great-tmp-path-replacement.patch
@@ -1,0 +1,469 @@
+From 201ce579ee6d26544e30b4ab7c2ad25bf1bacc7a Mon Sep 17 00:00:00 2001
+From: Faheem Pervez <trippin1@gmail.com>
+Date: Tue, 14 Apr 2020 03:51:05 +0100
+Subject: [PATCH 1/6] The great /tmp path replacement
+
+---
+ auth/credentials/credentials_krb5.c      | 2 +-
+ ctdb/tests/src/porting_tests.c           | 2 +-
+ lib/ldb/tools/ldbedit.c                  | 2 +-
+ lib/param/loadparm.c                     | 4 ++--
+ lib/replace/wscript                      | 6 +++---
+ lib/util/util.c                          | 2 +-
+ nsswitch/winbind_nss_aix.c               | 2 +-
+ source3/client/smbspool_krb5_wrapper.c   | 2 +-
+ source3/lib/smbconf/testsuite.c          | 2 +-
+ source3/modules/vfs_virusfilter.c        | 2 +-
+ source3/modules/vfs_virusfilter_fsav.c   | 2 +-
+ source3/registry/tests/test_regfio.c     | 2 +-
+ source3/rpc_server/srv_pipe.c            | 4 ++--
+ source3/smbd/notifyd/tests.c             | 4 ++--
+ source3/smbd/process.c                   | 2 +-
+ source3/utils/interact.c                 | 2 +-
+ source3/winbindd/winbindd_pam.c          | 4 ++--
+ source4/heimdal/lib/krb5/expand_path.c   | 4 ++--
+ source4/heimdal/lib/krb5/krb5-v4compat.h | 2 +-
+ source4/heimdal/lib/krb5/krb5.h          | 2 +-
+ source4/heimdal/lib/krb5/krb5_locl.h     | 2 +-
+ source4/librpc/tests/binding_string.c    | 4 ++--
+ source4/param/tests/share.c              | 6 +++---
+ testsuite/nsswitch/getgrent_r.c          | 4 ++--
+ testsuite/nsswitch/getpwent_r.c          | 4 ++--
+ testsuite/unittests/test_krb5_samba.c    | 4 ++--
+ third_party/pam_wrapper/pam_wrapper.c    | 2 +-
+ 27 files changed, 40 insertions(+), 40 deletions(-)
+
+diff --git a/auth/credentials/credentials_krb5.c b/auth/credentials/credentials_krb5.c
+index 20e677e..0353d44 100644
+--- a/auth/credentials/credentials_krb5.c
++++ b/auth/credentials/credentials_krb5.c
+@@ -624,7 +624,7 @@ static int cli_credentials_new_ccache(struct cli_credentials *cred,
+ 		must_free_cc_name = true;
+ 
+ 		if (lpcfg_parm_bool(lp_ctx, NULL, "credentials", "krb5_cc_file", false)) {
+-			ccache_name = talloc_asprintf(ccc, "FILE:/tmp/krb5_cc_samba_%u_%p", 
++			ccache_name = talloc_asprintf(ccc, "FILE:@TERMUX_PREFIX@/tmp/krb5_cc_samba_%u_%p",
+ 						      (unsigned int)getpid(), ccc);
+ 		} else {
+ 			ccache_name = talloc_asprintf(ccc, "MEMORY:%p", 
+diff --git a/ctdb/tests/src/porting_tests.c b/ctdb/tests/src/porting_tests.c
+index 8902c34..22128c7 100644
+--- a/ctdb/tests/src/porting_tests.c
++++ b/ctdb/tests/src/porting_tests.c
+@@ -41,7 +41,7 @@ static struct {
+ 	pid_t helper_pid;
+ 	int socket;
+ } globals = {
+-	.socketname = "/tmp/test.sock"
++	.socketname = "@TERMUX_PREFIX@/tmp/test.sock"
+ };
+ 
+ 
+diff --git a/lib/ldb/tools/ldbedit.c b/lib/ldb/tools/ldbedit.c
+index 5b83783..01b1662 100644
+--- a/lib/ldb/tools/ldbedit.c
++++ b/lib/ldb/tools/ldbedit.c
+@@ -218,7 +218,7 @@ static int do_edit(struct ldb_context *ldb, struct ldb_message **msgs1,
+ {
+ 	int fd, ret;
+ 	FILE *f;
+-	char file_template[] = "/tmp/ldbedit.XXXXXX";
++	char file_template[] = "@TERMUX_PREFIX@/tmp/ldbedit.XXXXXX";
+ 	char *cmd;
+ 	struct ldb_ldif *ldif;
+ 	struct ldb_message **msgs2 = NULL;
+diff --git a/lib/param/loadparm.c b/lib/param/loadparm.c
+index 6329128..7b2c9d0 100644
+--- a/lib/param/loadparm.c
++++ b/lib/param/loadparm.c
+@@ -2482,12 +2482,12 @@ void init_printer_values(struct loadparm_context *lp_ctx, TALLOC_CTX *ctx,
+ 
+ 		tmp = lpcfg_parm_string(lp_ctx, NULL, "vlp", "tdbfile");
+ 		if (tmp == NULL) {
+-			tmp = "/tmp/vlp.tdb";
++			tmp = "@TERMUX_PREFIX@/tmp/vlp.tdb";
+ 		}
+ 
+ 		tdbfile = talloc_asprintf(tmp_ctx, "tdbfile=%s", tmp);
+ 		if (tdbfile == NULL) {
+-			tdbfile="tdbfile=/tmp/vlp.tdb";
++			tdbfile="tdbfile=@TERMUX_PREFIX@/tmp/vlp.tdb";
+ 		}
+ 
+ 		tmp = talloc_asprintf(tmp_ctx, "vlp %s print %%p %%s",
+diff --git a/lib/replace/wscript b/lib/replace/wscript
+index ab2b3c0..4a523f4 100644
+--- a/lib/replace/wscript
++++ b/lib/replace/wscript
+@@ -779,8 +779,8 @@ def configure(conf):
+ 
+     conf.CHECK_CODE('''
+                     struct stat st;
+-                    char tpl[20]="/tmp/test.XXXXXX";
+-                    char tpl2[20]="/tmp/test.XXXXXX";
++                    char tpl[51]="@TERMUX_PREFIX@/tmp/test.XXXXXX";
++                    char tpl2[51]="@TERMUX_PREFIX@/tmp/test.XXXXXX";
+                     int fd = mkstemp(tpl);
+                     int fd2 = mkstemp(tpl2);
+                     if (fd == -1) {
+@@ -794,7 +794,7 @@ def configure(conf):
+                     unlink(tpl2);
+                     if (fstat(fd, &st) != 0) exit(1);
+                     if ((st.st_mode & 0777) != 0600) exit(1);
+-                    if (strcmp(tpl, "/tmp/test.XXXXXX") == 0) {
++                    if (strcmp(tpl, "@TERMUX_PREFIX@/tmp/test.XXXXXX") == 0) {
+                           exit(1);
+                     }
+                     if (strcmp(tpl, tpl2) == 0) {
+diff --git a/lib/util/util.c b/lib/util/util.c
+index 0d9ffe5..65a8d58 100644
+--- a/lib/util/util.c
++++ b/lib/util/util.c
+@@ -209,7 +209,7 @@ _PUBLIC_ const char *tmpdir(void)
+ 	char *p;
+ 	if ((p = getenv("TMPDIR")))
+ 		return p;
+-	return "/tmp";
++	return "@TERMUX_PREFIX@/tmp";
+ }
+ 
+ 
+diff --git a/nsswitch/winbind_nss_aix.c b/nsswitch/winbind_nss_aix.c
+index 343809a..5bfa625 100644
+--- a/nsswitch/winbind_nss_aix.c
++++ b/nsswitch/winbind_nss_aix.c
+@@ -63,7 +63,7 @@ static void logit(const char *format, ...)
+ 	if (!debug_enabled) {
+ 		return;
+ 	}
+-	f = fopen("/tmp/WINBIND_DEBUG.log", "a");
++	f = fopen("@TERMUX_PREFIX@/tmp/WINBIND_DEBUG.log", "a");
+ 	if (!f) return;
+ 	va_start(ap, format);
+ 	vfprintf(f, format, ap);
+diff --git a/source3/client/smbspool_krb5_wrapper.c b/source3/client/smbspool_krb5_wrapper.c
+index 6a3e444..606dd69 100644
+--- a/source3/client/smbspool_krb5_wrapper.c
++++ b/source3/client/smbspool_krb5_wrapper.c
+@@ -309,7 +309,7 @@ int main(int argc, char *argv[])
+ 	}
+ 
+ 	/* Fallback to a FILE ccache */
+-	snprintf(gen_cc, sizeof(gen_cc), "FILE:/tmp/krb5cc_%u", uid);
++	snprintf(gen_cc, sizeof(gen_cc), "FILE:@TERMUX_PREFIX@/tmp/krb5cc_%u", uid);
+ 
+ create_env:
+ 	/*
+diff --git a/source3/lib/smbconf/testsuite.c b/source3/lib/smbconf/testsuite.c
+index 0053f9f..a8f113f 100644
+--- a/source3/lib/smbconf/testsuite.c
++++ b/source3/lib/smbconf/testsuite.c
+@@ -208,7 +208,7 @@ static bool torture_smbconf_txt(void)
+ {
+ 	sbcErr err;
+ 	bool ret = true;
+-	const char *filename = "/tmp/smb.conf.smbconf_testsuite";
++	const char *filename = "@TERMUX_PREFIX@/tmp/smb.conf.smbconf_testsuite";
+ 	struct smbconf_ctx *conf_ctx = NULL;
+ 	TALLOC_CTX *mem_ctx = talloc_stackframe();
+ 
+diff --git a/source3/modules/vfs_virusfilter.c b/source3/modules/vfs_virusfilter.c
+index 12f0364..976fba7 100644
+--- a/source3/modules/vfs_virusfilter.c
++++ b/source3/modules/vfs_virusfilter.c
+@@ -267,7 +267,7 @@ static int virusfilter_vfs_connect(
+ 
+ 	config->quarantine_dir = lp_parm_const_string(
+ 		snum, "virusfilter", "quarantine directory",
+-		tmp ? tmp : "/tmp/.quarantine");
++		tmp ? tmp : "@TERMUX_PREFIX@/tmp/.quarantine");
+ 
+ 	if (tmp != config->quarantine_dir) {
+ 		TALLOC_FREE(tmp);
+diff --git a/source3/modules/vfs_virusfilter_fsav.c b/source3/modules/vfs_virusfilter_fsav.c
+index 240940c..06d7d66 100644
+--- a/source3/modules/vfs_virusfilter_fsav.c
++++ b/source3/modules/vfs_virusfilter_fsav.c
+@@ -23,7 +23,7 @@
+ #ifdef FSAV_DEFAULT_SOCKET_PATH
+ #  define VIRUSFILTER_DEFAULT_SOCKET_PATH	FSAV_DEFAULT_SOCKET_PATH
+ #else
+-#  define VIRUSFILTER_DEFAULT_SOCKET_PATH	"/tmp/.fsav-0"
++#  define VIRUSFILTER_DEFAULT_SOCKET_PATH	"@TERMUX_PREFIX@/tmp/.fsav-0"
+ #endif
+ 
+ /* Default values for module-specific configuration variables */
+diff --git a/source3/registry/tests/test_regfio.c b/source3/registry/tests/test_regfio.c
+index e835e65..d0e7143 100644
+--- a/source3/registry/tests/test_regfio.c
++++ b/source3/registry/tests/test_regfio.c
+@@ -65,7 +65,7 @@ static int setup_context_tempfile(void **state)
+ 	if (ret == 0) {
+ 		test_ctx = talloc_get_type_abort(*state, struct test_ctx);
+ 
+-		test_ctx->tmp_regfile = talloc_strdup(test_ctx, "/tmp/regfio.XXXXXX");
++		test_ctx->tmp_regfile = talloc_strdup(test_ctx, "@TERMUX_PREFIX@/tmp/regfio.XXXXXX");
+ 		assert_non_null(test_ctx->tmp_regfile);
+ 
+ 		test_ctx->tmp_regfile_fd = mkstemp(test_ctx->tmp_regfile);
+diff --git a/source3/rpc_server/srv_pipe.c b/source3/rpc_server/srv_pipe.c
+index 3bc291f..fce469a 100644
+--- a/source3/rpc_server/srv_pipe.c
++++ b/source3/rpc_server/srv_pipe.c
+@@ -75,11 +75,11 @@ static void dump_pdu_region(const char *name, int v,
+ 	for (i = 1; i < 100; i++) {
+ 		if (v != -1) {
+ 			fname = talloc_asprintf(talloc_tos(),
+-						"/tmp/%s_%d.%d.prs",
++						"@TERMUX_PREFIX@/tmp/%s_%d.%d.prs",
+ 						name, v, i);
+ 		} else {
+ 			fname = talloc_asprintf(talloc_tos(),
+-						"/tmp/%s_%d.prs",
++						"@TERMUX_PREFIX@/tmp/%s_%d.prs",
+ 						name, i);
+ 		}
+ 		if (!fname) {
+diff --git a/source3/smbd/notifyd/tests.c b/source3/smbd/notifyd/tests.c
+index 6bcce6a..7766a8c 100644
+--- a/source3/smbd/notifyd/tests.c
++++ b/source3/smbd/notifyd/tests.c
+@@ -66,12 +66,12 @@ int main(int argc, const char *argv[])
+ 			.instance.filter = UINT32_MAX,
+ 			.instance.subdir_filter = UINT32_MAX
+ 		};
+-		char path[64];
++		char path[256];
+ 		size_t len;
+ 		struct iovec iov[2];
+ 		NTSTATUS status;
+ 
+-		len = snprintf(path, sizeof(path), "/tmp%u", i);
++		len = snprintf(path, sizeof(path), "@TERMUX_PREFIX@/tmp%u", i);
+ 
+ 		iov[0].iov_base = &msg;
+ 		iov[0].iov_len = offsetof(struct notify_rec_change_msg, path);
+diff --git a/source3/smbd/process.c b/source3/smbd/process.c
+index 70398b4..6f97d23 100644
+--- a/source3/smbd/process.c
++++ b/source3/smbd/process.c
+@@ -1419,7 +1419,7 @@ static void smb_dump(const char *name, int type, const char *data)
+ 	len = smb_len_tcp(data)+4;
+ 	for (i=1;i<100;i++) {
+ 		fname = talloc_asprintf(talloc_tos(),
+-				"/tmp/%s.%d.%s",
++				"@TERMUX_PREFIX@/tmp/%s.%d.%s",
+ 				name,
+ 				i,
+ 				type ? "req" : "resp");
+diff --git a/source3/utils/interact.c b/source3/utils/interact.c
+index f8fed6d..73a4c54 100644
+--- a/source3/utils/interact.c
++++ b/source3/utils/interact.c
+@@ -76,7 +76,7 @@ int interact_prompt(const char* msg, const char* acc, char def) {
+ 
+ 
+ char* interact_edit(TALLOC_CTX* mem_ctx, const char* str) {
+-	char fname[] = "/tmp/net_idmap_check.XXXXXX";
++	char fname[] = "@TERMUX_PREFIX@/tmp/net_idmap_check.XXXXXX";
+ 	char buf[128];
+ 	char* ret = NULL;
+ 	FILE* file;
+diff --git a/source3/winbindd/winbindd_pam.c b/source3/winbindd/winbindd_pam.c
+index a3d8716..e0a68d8 100644
+--- a/source3/winbindd/winbindd_pam.c
++++ b/source3/winbindd/winbindd_pam.c
+@@ -572,11 +572,11 @@ static const char *generate_krb5_ccache(TALLOC_CTX *mem_ctx,
+ 	if (uid != -1) {
+ 		if (strequal(type, "FILE")) {
+ 			gen_cc = talloc_asprintf(
+-				mem_ctx, "FILE:/tmp/krb5cc_%d", uid);
++				mem_ctx, "FILE:@TERMUX_PREFIX@/tmp/krb5cc_%d", uid);
+ 		}
+ 		if (strequal(type, "WRFILE")) {
+ 			gen_cc = talloc_asprintf(
+-				mem_ctx, "WRFILE:/tmp/krb5cc_%d", uid);
++				mem_ctx, "WRFILE:@TERMUX_PREFIX@/tmp/krb5cc_%d", uid);
+ 		}
+ 		if (strequal(type, "KEYRING")) {
+ 			gen_cc = talloc_asprintf(
+diff --git a/source4/heimdal/lib/krb5/expand_path.c b/source4/heimdal/lib/krb5/expand_path.c
+index 1b46cea..8d97702 100644
+--- a/source4/heimdal/lib/krb5/expand_path.c
++++ b/source4/heimdal/lib/krb5/expand_path.c
+@@ -287,11 +287,11 @@ _expand_temp_folder(krb5_context context, PTYPE param, const char *postfix, char
+     const char *p = NULL;
+ 
+     if (issuid())
+-	p = getenv("TEMP");
++	p = getenv("TMPDIR");
+     if (p)
+ 	*ret = strdup(p);
+     else
+-	*ret = strdup("/tmp");
++	*ret = strdup("@TERMUX_PREFIX@/tmp");
+     if (*ret == NULL)
+ 	return ENOMEM;
+     return 0;
+diff --git a/source4/heimdal/lib/krb5/krb5-v4compat.h b/source4/heimdal/lib/krb5/krb5-v4compat.h
+index 324c8c1..b195137 100644
+--- a/source4/heimdal/lib/krb5/krb5-v4compat.h
++++ b/source4/heimdal/lib/krb5/krb5-v4compat.h
+@@ -108,7 +108,7 @@ struct credentials {
+ #ifdef KRB5_USE_PATH_TOKENS
+ #define TKT_ROOT "%{TEMP}/tkt"
+ #else
+-#define TKT_ROOT "/tmp/tkt"
++#define TKT_ROOT "@TERMUX_PREFIX@/tmp/tkt"
+ #endif
+ #endif
+ 
+diff --git a/source4/heimdal/lib/krb5/krb5.h b/source4/heimdal/lib/krb5/krb5.h
+index 9c0f566..6607fab 100644
+--- a/source4/heimdal/lib/krb5/krb5.h
++++ b/source4/heimdal/lib/krb5/krb5.h
+@@ -351,7 +351,7 @@ struct krb5_cc_ops;
+ #ifdef KRB5_USE_PATH_TOKENS
+ #define KRB5_DEFAULT_CCFILE_ROOT "%{TEMP}/krb5cc_"
+ #else
+-#define KRB5_DEFAULT_CCFILE_ROOT "/tmp/krb5cc_"
++#define KRB5_DEFAULT_CCFILE_ROOT "@TERMUX_PREFIX@/tmp/krb5cc_"
+ #endif
+ 
+ #define KRB5_DEFAULT_CCROOT "FILE:" KRB5_DEFAULT_CCFILE_ROOT
+diff --git a/source4/heimdal/lib/krb5/krb5_locl.h b/source4/heimdal/lib/krb5/krb5_locl.h
+index 49c614d..a17c71c 100644
+--- a/source4/heimdal/lib/krb5/krb5_locl.h
++++ b/source4/heimdal/lib/krb5/krb5_locl.h
+@@ -303,7 +303,7 @@ typedef struct krb5_context_data {
+ } krb5_context_data;
+ 
+ #ifndef KRB5_USE_PATH_TOKENS
+-#define KRB5_DEFAULT_CCNAME_FILE "FILE:/tmp/krb5cc_%{uid}"
++#define KRB5_DEFAULT_CCNAME_FILE "FILE:@TERMUX_PREFIX@/tmp/krb5cc_%{uid}"
+ #else
+ #define KRB5_DEFAULT_CCNAME_FILE "FILE:%{TEMP}/krb5cc_%{uid}"
+ #endif
+diff --git a/source4/librpc/tests/binding_string.c b/source4/librpc/tests/binding_string.c
+index 3ef7b7d..729d386 100644
+--- a/source4/librpc/tests/binding_string.c
++++ b/source4/librpc/tests/binding_string.c
+@@ -127,9 +127,9 @@ static const char *test_strings[] = {
+ 	"ncadg_ip_udp:",
+ 	"308FB580-1EB2-11CA-923B-08002B1075A7@ncacn_np:localhost",
+ 	"308FB580-1EB2-11CA-923B-08002B1075A7@ncacn_ip_tcp:127.0.0.1",
+-	"ncacn_unix_stream:[/tmp/epmapper]",
++	"ncacn_unix_stream:[@TERMUX_PREFIX@/tmp/epmapper]",
+ 	"ncalrpc:[IDENTIFIER]",
+-	"ncacn_unix_stream:[/tmp/epmapper,sign]",
++	"ncacn_unix_stream:[@TERMUX_PREFIX@/tmp/epmapper,sign]",
+ 	"ncacn_ip_tcp:127.0.0.1[75,target_hostname=port75.example.com,target_principal=host/port75.example.com]",
+ 	"ncacn_ip_tcp:127.0.0.1[75,connect,target_hostname=port75.example.com,target_principal=host/port75.example.com,assoc_group_id=0x01234567]",
+ 	"ncacn_ip_tcp:127.0.0.1[75,packet,target_hostname=port75.example.com,target_principal=host/port75.example.com,assoc_group_id=0x01234567]",
+diff --git a/source4/param/tests/share.c b/source4/param/tests/share.c
+index 6d786a8..6576337 100644
+--- a/source4/param/tests/share.c
++++ b/source4/param/tests/share.c
+@@ -50,7 +50,7 @@ static bool test_create(struct torture_context *tctx,
+ 	bool found = false;
+ 	struct share_info inf[] = { 
+ 		{ SHARE_INFO_STRING, SHARE_TYPE, discard_const_p(void *, "IPC$") },
+-		{ SHARE_INFO_STRING, SHARE_PATH, discard_const_p(void *, "/tmp/bla") }
++		{ SHARE_INFO_STRING, SHARE_PATH, discard_const_p(void *, "@TERMUX_PREFIX@/tmp/bla") }
+ 	};
+ 	NTSTATUS status;
+ 
+@@ -126,7 +126,7 @@ static bool test_share_remove(struct torture_context *tctx,
+ 	struct share_context *ctx = (struct share_context *)discard_const(tcase_data);
+ 	struct share_info inf[] = { 
+ 		{ SHARE_INFO_STRING, SHARE_TYPE, discard_const_p(void *, "IPC$") },
+-		{ SHARE_INFO_STRING, SHARE_PATH, discard_const_p(void *, "/tmp/bla") }
++		{ SHARE_INFO_STRING, SHARE_PATH, discard_const_p(void *, "@TERMUX_PREFIX@/tmp/bla") }
+ 	};
+ 	NTSTATUS status;
+ 
+@@ -149,7 +149,7 @@ static bool test_double_create(struct torture_context *tctx,
+ 	struct share_context *ctx = (struct share_context *)discard_const(tcase_data);
+ 	struct share_info inf[] = { 
+ 		{ SHARE_INFO_STRING, SHARE_TYPE, discard_const_p(void *, "IPC$") },
+-		{ SHARE_INFO_STRING, SHARE_PATH, discard_const_p(void *, "/tmp/bla") }
++		{ SHARE_INFO_STRING, SHARE_PATH, discard_const_p(void *, "@TERMUX_PREFIX@/tmp/bla") }
+ 	};
+ 	NTSTATUS status;
+ 
+diff --git a/testsuite/nsswitch/getgrent_r.c b/testsuite/nsswitch/getgrent_r.c
+index 883c897..33936f9 100644
+--- a/testsuite/nsswitch/getgrent_r.c
++++ b/testsuite/nsswitch/getgrent_r.c
+@@ -14,12 +14,12 @@
+ void dump_grent(char *id)
+ {
+     struct group *gr;
+-    char fname[255];
++    char fname[512];
+     FILE *fptr;
+ 
+     /* Open results file */
+ 
+-    sprintf(fname, "/tmp/getgrent_r-%s.out-%d", id, getpid());
++    sprintf(fname, "@TERMUX_PREFIX@/tmp/getgrent_r-%s.out-%d", id, getpid());
+ 
+     if ((fptr = fopen(fname, "w")) == NULL) {
+         fprintf(stderr, "ERROR: could not open file %s: %s\n", fname,
+diff --git a/testsuite/nsswitch/getpwent_r.c b/testsuite/nsswitch/getpwent_r.c
+index 5e77491..6113f85 100644
+--- a/testsuite/nsswitch/getpwent_r.c
++++ b/testsuite/nsswitch/getpwent_r.c
+@@ -14,12 +14,12 @@
+ void dump_pwent(char *id)
+ {
+     struct passwd *pw;
+-    char fname[255];
++    char fname[512];
+     FILE *fptr;
+ 
+     /* Open results file */
+ 
+-    sprintf(fname, "/tmp/getpwent_r-%s.out-%d", id, getpid());
++    sprintf(fname, "@TERMUX_PREFIX@/tmp/getpwent_r-%s.out-%d", id, getpid());
+ 
+     if ((fptr = fopen(fname, "w")) == 0) {
+         fprintf(stderr, "ERROR: could not open file %s: %s\n", fname,
+diff --git a/testsuite/unittests/test_krb5_samba.c b/testsuite/unittests/test_krb5_samba.c
+index 8b7e843..d4fce8a 100644
+--- a/testsuite/unittests/test_krb5_samba.c
++++ b/testsuite/unittests/test_krb5_samba.c
+@@ -37,7 +37,7 @@ static void test_smb_krb5_kt_open(void **state)
+ 	krb5_context context = *state;
+ 	krb5_keytab keytab = NULL;
+ 	krb5_error_code code;
+-	char keytab_template[] = "/tmp/keytab.XXXXXX";
++	char keytab_template[] = "@TERMUX_PREFIX@/tmp/keytab.XXXXXX";
+ 	int fd;
+ 
+ 	fd = mkstemp(keytab_template);
+@@ -59,7 +59,7 @@ static void test_smb_krb5_kt_open_file(void **state)
+ 	krb5_context context = *state;
+ 	krb5_keytab keytab = NULL;
+ 	krb5_error_code code;
+-	char keytab_template[] = "/tmp/keytab.XXXXXX";
++	char keytab_template[] = "@TERMUX_PREFIX@/tmp/keytab.XXXXXX";
+ 	char keytab_file[6 + strlen(keytab_template)];
+ 	int fd;
+ 
+diff --git a/third_party/pam_wrapper/pam_wrapper.c b/third_party/pam_wrapper/pam_wrapper.c
+index 48d2c2a..d96bf01 100644
+--- a/third_party/pam_wrapper/pam_wrapper.c
++++ b/third_party/pam_wrapper/pam_wrapper.c
+@@ -844,7 +844,7 @@ out:
+ 
+ static void pwrap_init(void)
+ {
+-	char tmp_config_dir[] = "/tmp/pam.X";
++	char tmp_config_dir[] = "@TERMUX_PREFIX@/tmp/pam.X";
+ 	size_t len = strlen(tmp_config_dir);
+ 	const char *env;
+ 	struct stat sb;
+-- 
+2.25.1
+

--- a/packages/samba/0002-Remove-setuid-etc.patch
+++ b/packages/samba/0002-Remove-setuid-etc.patch
@@ -1,0 +1,322 @@
+From f2914959c7a68f4457e43d99f4270647d66fcde2 Mon Sep 17 00:00:00 2001
+From: Faheem Pervez <trippin1@gmail.com>
+Date: Thu, 18 Jun 2020 00:39:50 +0000
+Subject: [PATCH 2/6] Remove setuid etc.
+
+When non-root, this only succeeds when SELinux is in permissive mode.
+---
+ lib/replace/wscript               |   6 +-
+ source3/lib/util_sec.c            |  16 ++---
+ source3/modules/vfs_aio_pthread.c |  19 ++----
+ source3/modules/vfs_default.c     |   2 -
+ source3/wscript                   | 109 +-----------------------------
+ tests/summary.c                   |   2 +
+ 6 files changed, 18 insertions(+), 136 deletions(-)
+
+diff --git a/lib/replace/wscript b/lib/replace/wscript
+index 4a523f4..a7a824d 100644
+--- a/lib/replace/wscript
++++ b/lib/replace/wscript
+@@ -389,8 +389,8 @@ def configure(conf):
+ 
+     conf.CHECK_FUNCS('shl_load shl_unload shl_findsym')
+     conf.CHECK_FUNCS('pipe strftime srandom random srand rand usleep setbuffer')
+-    conf.CHECK_FUNCS('lstat getpgrp utime utimes setuid seteuid setreuid setresuid setgid setegid')
+-    conf.CHECK_FUNCS('setregid setresgid chroot strerror vsyslog setlinebuf mktime')
++    conf.CHECK_FUNCS('lstat getpgrp utime utimes')
++    conf.CHECK_FUNCS('chroot strerror vsyslog setlinebuf mktime')
+     conf.CHECK_FUNCS('ftruncate chsize rename waitpid wait4')
+     conf.CHECK_FUNCS('initgroups pread pwrite strndup strcasestr strsep')
+     conf.CHECK_FUNCS('strtok_r mkdtemp dup2 dprintf vdprintf isatty chown lchown')
+@@ -460,7 +460,7 @@ def configure(conf):
+     conf.CHECK_FUNCS('if_nametoindex strerror_r')
+     conf.CHECK_FUNCS('syslog')
+     conf.CHECK_FUNCS('gai_strerror get_current_dir_name')
+-    conf.CHECK_FUNCS('timegm getifaddrs freeifaddrs mmap setgroups syscall setsid')
++    conf.CHECK_FUNCS('timegm getifaddrs freeifaddrs mmap syscall setsid')
+     conf.CHECK_FUNCS('getgrent_r getgrgid_r getgrnam_r getgrouplist getpagesize')
+     conf.CHECK_FUNCS('getpwent_r getpwnam_r getpwuid_r epoll_create')
+     conf.CHECK_FUNCS('port_create')
+diff --git a/source3/lib/util_sec.c b/source3/lib/util_sec.c
+index b6fb6c0..a4f049b 100644
+--- a/source3/lib/util_sec.c
++++ b/source3/lib/util_sec.c
+@@ -132,11 +132,11 @@ static void assert_uid(uid_t ruid, uid_t euid)
+ 	if ((euid != (uid_t)-1 && geteuid() != euid) ||
+ 	    (ruid != (uid_t)-1 && getuid() != ruid)) {
+ 		if (!non_root_mode()) {
+-			DEBUG(0,("Failed to set uid privileges to (%d,%d) now set to (%d,%d)\n",
++			DEBUG(5,("Failed to set uid privileges to (%d,%d) now set to (%d,%d)\n",
+ 				 (int)ruid, (int)euid,
+ 				 (int)getuid(), (int)geteuid()));
+-			smb_panic("failed to set uid\n");
+-			exit(1);
++			/* smb_panic("failed to set uid\n");
++			exit(1); */
+ 		}
+ 	}
+ }
+@@ -149,12 +149,12 @@ static void assert_gid(gid_t rgid, gid_t egid)
+ 	if ((egid != (gid_t)-1 && getegid() != egid) ||
+ 	    (rgid != (gid_t)-1 && getgid() != rgid)) {
+ 		if (!non_root_mode()) {
+-			DEBUG(0,("Failed to set gid privileges to (%d,%d) now set to (%d,%d) uid=(%d,%d)\n",
++			DEBUG(5,("Failed to set gid privileges to (%d,%d) now set to (%d,%d) uid=(%d,%d)\n",
+ 				 (int)rgid, (int)egid,
+ 				 (int)getgid(), (int)getegid(),
+ 				 (int)getuid(), (int)geteuid()));
+-			smb_panic("failed to set gid\n");
+-			exit(1);
++			/* smb_panic("failed to set gid\n");
++			exit(1); */
+ 		}
+ 	}
+ }
+@@ -501,11 +501,11 @@ int set_thread_credentials(uid_t uid,
+ 	if (samba_setresuid(uid, uid, -1) != 0) {
+ 		return -1;
+ 	}
+-	if (geteuid() != uid || getuid() != uid ||
++	/* if (geteuid() != uid || getuid() != uid ||
+ 			getegid() != gid || getgid() != gid) {
+ 		smb_panic("set_thread_credentials failed\n");
+ 		return -1;
+-	}
++	} */
+ 
+ #ifdef HAVE___THREAD
+ 	cache.active = true;
+diff --git a/source3/modules/vfs_aio_pthread.c b/source3/modules/vfs_aio_pthread.c
+index 1ccf89a..0c9c591 100644
+--- a/source3/modules/vfs_aio_pthread.c
++++ b/source3/modules/vfs_aio_pthread.c
+@@ -31,7 +31,7 @@
+ #include <linux/falloc.h>
+ #endif
+ 
+-#if defined(HAVE_OPENAT) && defined(HAVE_LINUX_THREAD_CREDENTIALS)
++#if defined(HAVE_OPENAT)
+ 
+ /*
+  * We must have openat() to do any thread-based
+@@ -52,7 +52,6 @@ struct aio_open_private_data {
+ 	char *dname;
+ 	connection_struct *conn;
+ 	struct smbXsrv_connection *xconn;
+-	const struct security_unix_token *ux_tok;
+ 	uint64_t initial_allocation_size;
+ 	/* Returns. */
+ 	int ret_fd;
+@@ -186,16 +185,6 @@ static void aio_open_worker(void *private_data)
+ 	struct aio_open_private_data *opd =
+ 		(struct aio_open_private_data *)private_data;
+ 
+-	/* Become the correct credential on this thread. */
+-	if (set_thread_credentials(opd->ux_tok->uid,
+-				opd->ux_tok->gid,
+-				(size_t)opd->ux_tok->ngroups,
+-				opd->ux_tok->groups) != 0) {
+-		opd->ret_fd = -1;
+-		opd->ret_errno = errno;
+-		return;
+-	}
+-
+ 	aio_open_do(opd);
+ }
+ 
+@@ -280,11 +269,11 @@ static struct aio_open_private_data *create_private_open_data(TALLOC_CTX *ctx,
+ 	};
+ 
+ 	/* Copy our current credentials. */
+-	opd->ux_tok = copy_unix_token(opd, get_current_utok(fsp->conn));
++	/*opd->ux_tok = copy_unix_token(opd, get_current_utok(fsp->conn));
+ 	if (opd->ux_tok == NULL) {
+ 		opd_free(opd);
+ 		return NULL;
+-	}
++	}*/
+ 
+ 	/*
+ 	 * Copy the parent directory name and the
+@@ -488,7 +477,7 @@ static int aio_pthread_open_fn(vfs_handle_struct *handle,
+ #endif
+ 
+ static struct vfs_fn_pointers vfs_aio_pthread_fns = {
+-#if defined(HAVE_OPENAT) && defined(HAVE_LINUX_THREAD_CREDENTIALS)
++#if defined(HAVE_OPENAT)
+ 	.open_fn = aio_pthread_open_fn,
+ #endif
+ };
+diff --git a/source3/modules/vfs_default.c b/source3/modules/vfs_default.c
+index 4cf5534..5341c04 100644
+--- a/source3/modules/vfs_default.c
++++ b/source3/modules/vfs_default.c
+@@ -3276,9 +3276,7 @@ static struct tevent_req *vfswrap_getxattrat_send(
+ 		 */
+ 		have_per_thread_cwd = per_thread_cwd_supported();
+ 	}
+-#ifdef HAVE_LINUX_THREAD_CREDENTIALS
+ 	have_per_thread_creds = true;
+-#endif
+ 	if (have_per_thread_cwd && have_per_thread_creds) {
+ 		do_async = true;
+ 	}
+diff --git a/source3/wscript b/source3/wscript
+index 85466b4..c3c9ae5 100644
+--- a/source3/wscript
++++ b/source3/wscript
+@@ -109,7 +109,7 @@ def configure(conf):
+     conf.CHECK_FUNCS('setsid glob strpbrk crypt16 getauthuid')
+     conf.CHECK_FUNCS('innetgr')
+     conf.CHECK_FUNCS('initgroups select poll rdchk getgrnam getgrent pathconf')
+-    conf.CHECK_FUNCS('setpriv setgidx setuidx setgroups syscall sysconf')
++    conf.CHECK_FUNCS('setpriv syscall sysconf')
+     conf.CHECK_FUNCS('atexit grantpt posix_openpt fallocate')
+     conf.CHECK_FUNCS('fseeko setluid')
+     conf.CHECK_FUNCS('getpwnam', headers='sys/types.h pwd.h')
+@@ -430,15 +430,12 @@ pwrite
+ rdchk
+ select
+ setenv
+-setgidx
+-setgroups
+ setlocale
+ setluid
+ setmntent
+ setpgid
+ setpriv
+ setsid
+-setuidx
+ statvfs
+ strcasecmp
+ strchr
+@@ -964,110 +961,6 @@ int i; i = PAM_RADIO_TYPE;
+ #
+ # Ensure we select the correct set of system calls on Linux.
+ #
+-    if (host_os.rfind('linux') > -1):
+-        conf.CHECK_CODE('''
+-#if defined(HAVE_UNISTD_H)
+-#include <unistd.h>
+-#endif
+-#include <stdlib.h>
+-#include <stdio.h>
+-#include <sys/types.h>
+-#include <errno.h>
+-
+-#ifdef HAVE_SYS_PRIV_H
+-#include <sys/priv.h>
+-#endif
+-#ifdef HAVE_SYS_ID_H
+-#include <sys/id.h>
+-#endif
+-
+-#if defined(HAVE_SYSCALL_H)
+-#include <syscall.h>
+-#endif
+-
+-#if defined(HAVE_SYS_SYSCALL_H)
+-#include <sys/syscall.h>
+-#endif
+-
+-syscall(SYS_setresuid32, -1, -1, -1);
+-syscall(SYS_setresgid32, -1, -1, -1);
+-syscall(SYS_setreuid32, -1, -1);
+-syscall(SYS_setregid32, -1, -1);
+-syscall(SYS_setuid32, -1);
+-syscall(SYS_setgid32, -1);
+-syscall(SYS_setgroups32, 0, NULL);
+-''',
+-            'USE_LINUX_32BIT_SYSCALLS',
+-            msg="Checking whether Linux should use 32-bit credential calls");
+-
+-        if (conf.CONFIG_SET('USE_LINUX_32BIT_SYSCALLS')):
+-            seteuid = conf.CHECK_CODE('''
+-                                #define AUTOCONF_TEST 1
+-                                #define HAVE_LINUX_THREAD_CREDENTIALS 1
+-                                #define USE_LINUX_32BIT_SYSCALLS 1
+-                                #include "../lib/util/setid.c"
+-                                #include "./lib/util_sec.c"
+-                                ''',
+-                                'HAVE_LINUX_THREAD_CREDENTIALS',
+-                                addmain=False,
+-                                execute=True,
+-                                msg="Checking whether we can use Linux thread-specific credentials with 32-bit system calls")
+-        else:
+-            seteuid = conf.CHECK_CODE('''
+-                                #define AUTOCONF_TEST 1
+-                                #define HAVE_LINUX_THREAD_CREDENTIALS 1
+-                                #include "../lib/util/setid.c"
+-                                #include "./lib/util_sec.c"
+-                                ''',
+-                                'HAVE_LINUX_THREAD_CREDENTIALS',
+-                                addmain=False,
+-                                execute=True,
+-                                msg="Checking whether we can use Linux thread-specific credentials")
+-    if not seteuid:
+-        seteuid = conf.CHECK_CODE('''
+-                                #define AUTOCONF_TEST 1
+-                                #define USE_SETREUID 1
+-                                #include "../lib/util/setid.c"
+-                                #include "./lib/util_sec.c"
+-                                ''',
+-                                'USE_SETREUID',
+-                                addmain=False,
+-                                execute=True,
+-                                msg="Checking whether setreuid is available")
+-    if not seteuid:
+-        seteuid = conf.CHECK_CODE('''
+-                                #define AUTOCONF_TEST 1
+-                                #define USE_SETRESUID 1
+-                                #include "../lib/util/setid.c"
+-                                #include "./lib/util_sec.c"
+-                                ''',
+-                                'USE_SETRESUID',
+-                                addmain=False,
+-                                execute=True,
+-                                msg="Checking whether setresuid is available")
+-    if not seteuid:
+-        seteuid = conf.CHECK_CODE('''
+-                                #define AUTOCONF_TEST 1
+-                                #define USE_SETEUID 1
+-                                #include "../lib/util/setid.c"
+-                                #include "./lib/util_sec.c"
+-                                ''',
+-                                'USE_SETEUID',
+-                                addmain=False,
+-                                execute=True,
+-                                msg="Checking whether seteuid is available")
+-    if not seteuid:
+-        seteuid = conf.CHECK_CODE('''
+-                                #define AUTOCONF_TEST 1
+-                                #define USE_SETUIDX 1
+-                                #include "../lib/util/setid.c"
+-                                #include "./lib/util_sec.c"
+-                                ''',
+-                                'USE_SETUIDX',
+-                                addmain=False,
+-                                execute=True,
+-                                mandatory=True,
+-                                msg="Checking whether setuidx is available")
+     if Options.options.with_dnsupdate:
+         if not conf.CONFIG_SET('HAVE_KRB5'):
+             Logs.warn("--with-dnsupdate=yes but gssapi support not sufficient")
+diff --git a/tests/summary.c b/tests/summary.c
+index 87a64fd..f67197e 100644
+--- a/tests/summary.c
++++ b/tests/summary.c
+@@ -12,9 +12,11 @@ int main()
+ #warning "WARNING: No automated network interface determination"
+ #endif
+ 
++#ifndef __ANDROID__
+ #if !(defined(USE_SETEUID) || defined(USE_SETREUID) || defined(USE_SETRESUID) || defined(USE_SETUIDX) || defined(HAVE_LINUX_THREAD_CREDENTIALS))
+ #error "ERROR: no seteuid method available"
+ #endif
++#endif
+ 
+ #if !(defined(STAT_STATVFS) || defined(STAT_STATFS3_OSF1) || defined(STAT_STATFS2_BSIZE) || defined(STAT_STATFS4) || defined(STAT_STATFS2_FSIZE) || defined(STAT_STATFS2_FS_DATA))
+ #error "ERROR: No disk free routine!"
+-- 
+2.25.1
+

--- a/packages/samba/0003-smbpasswd-remove-root-related-restrictions.patch
+++ b/packages/samba/0003-smbpasswd-remove-root-related-restrictions.patch
@@ -1,0 +1,82 @@
+From a44362b264f38cff9bd8a1c3412bb3a7875c3a10 Mon Sep 17 00:00:00 2001
+From: Faheem Pervez <trippin1@gmail.com>
+Date: Tue, 14 Apr 2020 21:27:20 +0100
+Subject: [PATCH 3/6] smbpasswd: remove root-related restrictions
+
+* Allow -L to work when non-root
+* Allow deleting and renaming of user with uid = 0
+  A good sanity check, indeed, but when getpwnam etc. is modified
+  to return a passwd entry for root only, then this poses a problem...
+---
+ source3/passdb/pdb_interface.c | 22 ----------------------
+ source3/utils/smbpasswd.c      |  4 ----
+ 2 files changed, 26 deletions(-)
+
+diff --git a/source3/passdb/pdb_interface.c b/source3/passdb/pdb_interface.c
+index 03aa4ff..b1a7fb1 100644
+--- a/source3/passdb/pdb_interface.c
++++ b/source3/passdb/pdb_interface.c
+@@ -619,23 +619,12 @@ static NTSTATUS pdb_default_delete_user(struct pdb_methods *methods,
+ NTSTATUS pdb_delete_user(TALLOC_CTX *mem_ctx, struct samu *sam_acct)
+ {
+ 	struct pdb_methods *pdb = pdb_get_methods();
+-	uid_t uid = -1;
+ 	NTSTATUS status;
+ 	const struct dom_sid *user_sid;
+ 	char *msg_data;
+ 
+ 	user_sid = pdb_get_user_sid(sam_acct);
+ 
+-	/* sanity check to make sure we don't delete root */
+-
+-	if ( !sid_to_uid(user_sid, &uid ) ) {
+-		return NT_STATUS_NO_SUCH_USER;
+-	}
+-
+-	if ( uid == 0 ) {
+-		return NT_STATUS_ACCESS_DENIED;
+-	}
+-
+ 	memcache_delete(NULL,
+ 			PDB_GETPWSID_CACHE,
+ 			data_blob_const(user_sid, sizeof(*user_sid)));
+@@ -691,21 +680,10 @@ NTSTATUS pdb_delete_sam_account(struct samu *sam_acct)
+ NTSTATUS pdb_rename_sam_account(struct samu *oldname, const char *newname)
+ {
+ 	struct pdb_methods *pdb = pdb_get_methods();
+-	uid_t uid;
+ 	NTSTATUS status;
+ 
+ 	memcache_flush(NULL, PDB_GETPWSID_CACHE);
+ 
+-	/* sanity check to make sure we don't rename root */
+-
+-	if ( !sid_to_uid( pdb_get_user_sid(oldname), &uid ) ) {
+-		return NT_STATUS_NO_SUCH_USER;
+-	}
+-
+-	if ( uid == 0 ) {
+-		return NT_STATUS_ACCESS_DENIED;
+-	}
+-
+ 	status = pdb->rename_sam_account(pdb, oldname, newname);
+ 
+ 	/* always flush the cache here just to be safe */
+diff --git a/source3/utils/smbpasswd.c b/source3/utils/smbpasswd.c
+index 4013120..4688257 100644
+--- a/source3/utils/smbpasswd.c
++++ b/source3/utils/smbpasswd.c
+@@ -100,10 +100,6 @@ static int process_options(int argc, char **argv, int local_flags)
+ 	while ((ch = getopt(argc, argv, "c:axdehminjr:sw:R:D:U:LWS:")) != EOF) {
+ 		switch(ch) {
+ 		case 'L':
+-			if (getuid() != 0) {
+-				fprintf(stderr, "smbpasswd -L can only be used by root.\n");
+-				exit(1);
+-			}
+ 			local_flags |= LOCAL_AM_ROOT;
+ 			break;
+ 		case 'c':
+-- 
+2.25.1
+

--- a/packages/samba/0004-Skip-ftruncate-on-shares-marked-as-fstype-FAT-.patch
+++ b/packages/samba/0004-Skip-ftruncate-on-shares-marked-as-fstype-FAT-.patch
@@ -1,0 +1,35 @@
+From 63a467a95337f7eb1ea5c608c9286e96e3eb79ea Mon Sep 17 00:00:00 2001
+From: Faheem Pervez <trippin1@gmail.com>
+Date: Tue, 19 May 2020 04:58:13 +0100
+Subject: [PATCH 4/6] Skip ftruncate on shares marked as fstype FAT by
+ user
+
+vfat doesn't do sparse files, so creating a file >= 200MB full of actual
+zeros on a slow microSD card takes its sweet time. So much so that Windows
+gives up on trying to copy the file to a FAT share.
+
+It's a known problem, apparently:
+https://lists.samba.org/archive/samba/2008-June/141343.html
+https://www.cnblogs.com/flychown/p/6548021.html
+https://osdn.net/projects/sfnet_routertesting/downloads/ea6900%20patches/samba_009_FAT_fix.patch/
+https://forum.xda-developers.com/android/apps-games/app-samba-filesharing-server-android-t2803452
+---
+ source3/modules/vfs_default.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/source3/modules/vfs_default.c b/source3/modules/vfs_default.c
+index 5341c04..b182898 100644
+--- a/source3/modules/vfs_default.c
++++ b/source3/modules/vfs_default.c
+@@ -2665,7 +2665,7 @@ static int vfswrap_ftruncate(vfs_handle_struct *handle, files_struct *fsp, off_t
+ 	   expansion and some that don't! On Linux fat can't do
+ 	   ftruncate extend but ext2 can. */
+ 
+-	result = ftruncate(fsp->fh->fd, len);
++	result = strequal(lp_fstype(SNUM(fsp->conn)), "FAT") ? 0 : ftruncate(fsp->fh->fd, len);
+ 
+ 	/* According to W. R. Stevens advanced UNIX prog. Pure 4.3 BSD cannot
+ 	   extend a file with ftruncate. Provide alternate implementation
+-- 
+2.25.1
+

--- a/packages/samba/0005-samba-documents-provider-sambapatch.patch
+++ b/packages/samba/0005-samba-documents-provider-sambapatch.patch
@@ -1,0 +1,547 @@
+From cf315c2f59829ea70179e2f5342c19c796e7350c Mon Sep 17 00:00:00 2001
+From: Garfield Tan <xutan@google.com>
+Date: Thu, 18 Jun 2020 11:16:13 +0000
+Subject: [PATCH 5/6] samba-documents-provider-sambapatch
+
+https://github.com/google/samba-documents-provider/blob/master/sambapatch.diff
+
+smbd crash fix:
+https://github.com/elliott10/samba-4.5.1
+---
+ lib/param/loadparm.h               |   1 +
+ lib/replace/getifaddrs.c           |   8 +
+ lib/replace/netlink_ifaddrs.c      | 271 +++++++++++++++++++++++++++++
+ lib/replace/replace.c              |  14 ++
+ lib/replace/replace.h              |   5 +
+ lib/socket/interfaces.c            |   4 +
+ lib/util/util_pw.c                 |   2 -
+ librpc/ndr/util.c                  |   2 +-
+ nsswitch/libwbclient/wbc_pwd.c     |   5 -
+ nsswitch/libwbclient/wbc_sid.c     |   2 +-
+ nsswitch/winbind_struct_protocol.h |   4 +
+ source3/lib/dumpcore.c             |   2 +-
+ source3/lib/username.c             |   2 +
+ source3/passdb/passdb.c            |   1 +
+ source4/lib/socket/socket.c        |   2 +-
+ 15 files changed, 314 insertions(+), 11 deletions(-)
+ create mode 100644 lib/replace/netlink_ifaddrs.c
+
+diff --git a/lib/param/loadparm.h b/lib/param/loadparm.h
+index 65ff62c..e15546e 100644
+--- a/lib/param/loadparm.h
++++ b/lib/param/loadparm.h
+@@ -31,6 +31,7 @@
+ #define _LOADPARM_H
+ 
+ #include <talloc.h>
++#include "system/time.h"
+ 
+ struct parmlist_entry {
+ 	struct parmlist_entry *prev, *next;
+diff --git a/lib/replace/getifaddrs.c b/lib/replace/getifaddrs.c
+index a55ef7e..3f4f920 100644
+--- a/lib/replace/getifaddrs.c
++++ b/lib/replace/getifaddrs.c
+@@ -44,6 +44,7 @@
+ #define _FOUND_IFACE_ANY
+ #else
+ 
++#ifndef __ANDROID__
+ void rep_freeifaddrs(struct ifaddrs *ifp)
+ {
+ 	if (ifp != NULL) {
+@@ -55,6 +56,7 @@ void rep_freeifaddrs(struct ifaddrs *ifp)
+ 		free(ifp);
+ 	}
+ }
++#endif // __ANDROID__
+ 
+ static struct sockaddr *sockaddr_dup(struct sockaddr *sa)
+ {
+@@ -374,6 +376,12 @@ int rep_getifaddrs(struct ifaddrs **ifap)
+ 
+ #define _FOUND_IFACE_ANY
+ #endif /* HAVE_IFACE_AIX */
++
++#ifdef __ANDROID__
++#include "netlink_ifaddrs.c"
++#define _FOUND_IFACE_ANY
++#endif /* __ANDROID__ */
++
+ #ifndef _FOUND_IFACE_ANY
+ int rep_getifaddrs(struct ifaddrs **ifap)
+ {
+diff --git a/lib/replace/netlink_ifaddrs.c b/lib/replace/netlink_ifaddrs.c
+new file mode 100644
+index 0000000..4b0456b
+--- /dev/null
++++ b/lib/replace/netlink_ifaddrs.c
+@@ -0,0 +1,271 @@
++#include "system/network.h"
++
++#include <errno.h>
++#include <linux/if_packet.h>
++#include <net/if.h>
++#include <netinet/in.h>
++#include <linux/netlink.h>
++#include <linux/rtnetlink.h>
++#include <sys/socket.h>
++#include <stdlib.h>
++
++#define MAX_SIZE 8192
++char *__netlink_data_;
++
++struct ifaddrs_container {
++  // This needs to be the first because we use this struct as a ifaddrs struct.
++  struct ifaddrs ifa;
++
++  int idx;
++
++  // Storage for pointers in ifa
++  struct sockaddr_storage addr;
++  struct sockaddr_storage netmask;
++  struct sockaddr_storage dstaddr;
++  char name[IFNAMSIZ  1];
++};
++
++static void init(struct ifaddrs_container *ifa, struct ifaddrs_container** ifap) {
++  memset(ifa, 0, sizeof(*ifa));
++
++  ifa->ifa.ifa_next = (struct ifaddrs*)(*ifap);
++  *ifap = ifa;
++}
++
++static uint8_t* addr_bytes(int family, struct sockaddr_storage *ss) {
++  switch (family) {
++    case AF_INET: {
++      struct sockaddr_in *ss4 = (struct sockaddr_in *)ss;
++      return (uint8_t*) (&ss4->sin_addr);
++    }
++    case AF_INET6: {
++      struct sockaddr_in6 *ss6 = (struct sockaddr_in6 *)ss;
++      return (uint8_t*) (&ss6->sin6_addr);
++    }
++    case AF_PACKET: {
++      struct sockaddr_ll* sll = (struct sockaddr_ll*)ss;
++      return (uint8_t*) (&sll->sll_addr);
++    }
++    default:
++      return NULL;
++  }
++}
++
++static struct sockaddr* copy_addr(int family, const void* data, size_t byteCount, struct sockaddr_storage *ss, int idx) {
++  ss->ss_family = family;
++  memcpy(addr_bytes(family, ss), data, byteCount);
++
++  if (family == AF_INET6 && (IN6_IS_ADDR_LINKLOCAL((struct in6_addr*)data) || IN6_IS_ADDR_MC_LINKLOCAL((struct in6_addr*)data))) {
++    struct sockaddr_in6* ss6 = (struct sockaddr_in6*)ss;
++    ss6->sin6_scope_id = idx;
++  }
++
++  return (struct sockaddr*)ss;
++}
++
++static void set_addr(struct ifaddrs_container *ifa, int family, const void *data, size_t byteCount) {
++  if (ifa->ifa.ifa_addr = NULL) {
++    // Assume this is IFA_LOCAL, if not set_local_addr will fix it.
++    ifa->ifa.ifa_addr = copy_addr(family, data, byteCount, &ifa->addr, ifa->idx);
++  } else {
++    // We already have a IFA_LOCAL, this should be a destination address.
++    ifa->ifa.ifa_dstaddr = copy_addr(family, data, byteCount, &ifa->dstaddr, ifa->idx);
++  }
++}
++
++static void set_local_addr(struct ifaddrs_container *ifa, int family, const void *data, size_t byteCount) {
++  // For P2P interface IFA_ADDRESS is destination and local address is supplied
++  // in IFA_LOCAL attribute.
++  if (ifa->ifa.ifa_addr != NULL) {
++    ifa->ifa.ifa_dstaddr = (struct sockaddr*)memcpy(&ifa->dstaddr, &ifa->addr, sizeof(ifa->addr));
++  }
++
++  ifa->ifa.ifa_addr = copy_addr(family, data, byteCount, &ifa->addr, ifa->idx);
++}
++
++static void set_netmask(struct ifaddrs_container *ifa, int family, size_t prefix_len) {
++  ifa->netmask.ss_family = family;
++  uint8_t *dst = addr_bytes(family, &ifa->netmask);
++  memset(dst, 0xff, prefix_len / 8);
++  if ((prefix_len % 8) != 0) {
++    dst[prefix_len / 8] = (0xff << (8 - (prefix_len % 8)));
++  }
++  ifa->ifa.ifa_netmask = (struct sockaddr*)(&ifa->netmask);
++}
++
++static void set_packet_attr(struct ifaddrs_container *ifa, int ifindex, unsigned short hatype, unsigned char halen) {
++  struct sockaddr_ll *sll = (struct sockaddr_ll *)(&ifa->addr);
++  sll->sll_ifindex = ifindex;
++  sll->sll_hatype = hatype;
++  sll->sll_halen = halen;
++}
++
++static int send_request(int socket, int type) {
++  struct {
++    struct nlmsghdr hdr;
++    struct rtgenmsg msg;
++  } request;
++  memset(&request, 0, sizeof(request));
++  request.hdr.nlmsg_flags = NLM_F_DUMP | NLM_F_REQUEST;
++  request.hdr.nlmsg_type = type;
++  request.hdr.nlmsg_len = sizeof(request);
++  request.msg.rtgen_family = AF_UNSPEC;
++
++  int result = send(socket, &request, sizeof(request), 0);
++  return result == sizeof(request) ? 0 : -1;
++}
++
++static int read_response(int socket, struct ifaddrs_container **ifap, int (*callback)(struct ifaddrs_container**, struct nlmsghdr*)) {
++  if (!__netlink_data_) {
++    return -1;
++  }
++
++  ssize_t bytes_read;
++  while ((bytes_read = recv(socket, __netlink_data_, MAX_SIZE, 0)) > 0) {
++    struct nlmsghdr *hdr = (struct nlmsghdr *)__netlink_data_;
++    for (; NLMSG_OK(hdr, (size_t) bytes_read); hdr = NLMSG_NEXT(hdr, bytes_read)) {
++      switch (hdr->nlmsg_type) {
++        case NLMSG_DONE:
++          return 0;
++        case NLMSG_ERROR: {
++          struct nlmsgerr *err = (struct nlmsgerr *)NLMSG_DATA(hdr);
++          errno = (hdr->nlmsg_len >= NLMSG_LENGTH(sizeof(struct nlmsgerr))) ? -err->error : EIO;
++          return -1;
++        }
++        default:
++          if (callback(ifap, hdr)) {
++            return -1;
++          }
++      }
++    }
++  }
++
++  // Recv fails before we see NLMSG_OK.
++  return -1;
++}
++
++static int __newlink_callback(struct ifaddrs_container** ifap, struct nlmsghdr* hdr) {
++  if (hdr->nlmsg_type != RTM_NEWLINK) {
++    return -1;
++  }
++
++  struct ifinfomsg* ifi = (struct ifinfomsg *)NLMSG_DATA(hdr);
++  struct ifaddrs_container *addr = (struct ifaddrs_container *)malloc(sizeof(struct ifaddrs_container));
++  init(addr, ifap);
++  addr->idx = ifi->ifi_index;
++  addr->ifa.ifa_flags = ifi->ifi_flags;
++
++  struct rtattr *rta = IFLA_RTA(ifi);
++  size_t rta_len = IFLA_PAYLOAD(hdr);
++  for (; RTA_OK(rta, rta_len); rta = RTA_NEXT(rta, rta_len)) {
++    switch (rta->rta_type) {
++      case IFLA_ADDRESS:
++        if (RTA_PAYLOAD(rta) < sizeof(addr->addr)) {
++          set_addr(addr, AF_PACKET, RTA_DATA(rta), RTA_PAYLOAD(rta));
++          set_packet_attr(addr, ifi->ifi_index, ifi->ifi_type, RTA_PAYLOAD(rta));
++        }
++        break;
++      case IFLA_BROADCAST:
++        if (RTA_PAYLOAD(rta) < sizeof(addr->dstaddr)) {
++          set_packet_attr(addr, ifi->ifi_index, ifi->ifi_type, RTA_PAYLOAD(rta));
++        }
++        break;
++      case IFLA_IFNAME:
++        if (RTA_PAYLOAD(rta) < sizeof(addr->name)) {
++          memcpy(addr->name, RTA_DATA(rta), RTA_PAYLOAD(rta));
++          addr->ifa.ifa_name = addr->name;
++        }
++        break;
++      default:
++        break;
++    }
++  }
++
++  return 0;
++}
++
++static int __newaddr_callback(struct ifaddrs_container** ifap, struct nlmsghdr* hdr) {
++  if (hdr->nlmsg_type != RTM_NEWADDR) {
++    return -1;
++  }
++
++  struct ifaddrmsg *msg = (struct ifaddrmsg*)NLMSG_DATA(hdr);
++  const struct ifaddrs_container *addr = (const struct ifaddrs_container *)(*ifap);
++  while (addr != NULL && addr->idx != (int)msg->ifa_index) {
++    addr = (const struct ifaddrs_container *)addr->ifa.ifa_next;
++  }
++  if (addr == NULL) {
++    // Unknown interface... Ignore it and treat it as successful.
++    return 0;
++  }
++
++  // Copy whatever we know about the interface.
++  struct ifaddrs_container *new_addr = (struct ifaddrs_container *)malloc(sizeof(struct ifaddrs_container));
++  init(new_addr, ifap);
++  strcpy(new_addr->name, addr->name);
++  new_addr->ifa.ifa_name = new_addr->name;
++  new_addr->ifa.ifa_flags = addr->ifa.ifa_flags;
++  new_addr->idx = addr->idx;
++
++  struct rtattr *rta = IFA_RTA(msg);
++  size_t rta_len = IFA_PAYLOAD(hdr);
++  for (; RTA_OK(rta, rta_len); rta = RTA_NEXT(rta, rta_len)) {
++    switch (rta->rta_type) {
++      case IFA_ADDRESS:
++        if (msg->ifa_family == AF_INET || msg->ifa_family == AF_INET6) {
++          set_addr(new_addr, msg->ifa_family, RTA_DATA(rta), RTA_PAYLOAD(rta));
++          set_netmask(new_addr, msg->ifa_family, msg->ifa_prefixlen);
++        }
++        break;
++      case IFA_LOCAL:
++        if (msg->ifa_family == AF_INET || msg->ifa_family == AF_INET6) {
++          set_local_addr(new_addr, msg->ifa_family, RTA_DATA(rta), RTA_PAYLOAD(rta));
++        }
++        break;
++      default:
++        break;
++    }
++  }
++
++  return 0;
++}
++
++int rep_getifaddrs(struct ifaddrs **ifap) {
++  *ifap = NULL;
++
++  __netlink_data_ = (char *) malloc(MAX_SIZE);
++  if (!__netlink_data_) {
++    errno = ENOMEM;
++    return -1;
++  }
++
++  int fd = socket(PF_NETLINK, SOCK_RAW | SOCK_CLOEXEC, NETLINK_ROUTE);
++  if (fd < 0) {
++    errno = EIO;
++    return -1;
++  }
++
++  int result = send_request(fd, RTM_GETLINK) || read_response(fd, (struct ifaddrs_container**)ifap, __newlink_callback) ||
++      send_request(fd, RTM_GETADDR) || read_response(fd, (struct ifaddrs_container**)ifap, __newaddr_callback);
++
++  close(fd);
++
++  free(__netlink_data_);
++  __netlink_data_ = NULL;
++
++  if (result) {
++    freeifaddrs(*ifap);
++    *ifap = NULL;
++    return -1;
++  }
++
++  return 0;
++}
++
++void rep_freeifaddrs(struct ifaddrs *ifap) {
++  while (ifap != NULL) {
++    struct ifaddrs *cur = ifap;
++    ifap = ifap->ifa_next;
++    free(cur);
++  }
++}
+diff --git a/lib/replace/replace.c b/lib/replace/replace.c
+index 99b18e8..d77fa18 100644
+--- a/lib/replace/replace.c
++++ b/lib/replace/replace.c
+@@ -948,6 +948,20 @@ void rep_setproctitle_init(int argc, char *argv[], char *envp[])
+ }
+ #endif
+ 
++#ifndef HAVE_SWAB
++void rep_swab(const void *from, void *to, ssize_t n) {
++  ssize_t i;
++  if (n <= 0)
++    return;
++
++  n >>= 1;
++  for (i = 0; i < n; ++i) {
++    uint16_t src = *((uint16_t*)from+i);
++    *((uint16_t*)to+i) = (((src & 0x00ffU) << 8) | ((src & 0xff00U) >> 8));
++  }
++}
++#endif /* HAVE_SWAB */
++
+ #ifndef HAVE_MEMSET_S
+ # ifndef RSIZE_MAX
+ #  define RSIZE_MAX (SIZE_MAX >> 1)
+diff --git a/lib/replace/replace.h b/lib/replace/replace.h
+index 3f6b138..1c24ddb 100644
+--- a/lib/replace/replace.h
++++ b/lib/replace/replace.h
+@@ -958,6 +958,11 @@ const char *rep_getprogname(void);
+ # endif /* HAVE_FALLTHROUGH_ATTRIBUTE */
+ #endif /* FALL_THROUGH */
+ 
++#ifndef HAVE_SWAB
++#define swab rep_swab
++void rep_swab(const void *from, void *to, ssize_t n);
++#endif
++
+ bool nss_wrapper_enabled(void);
+ bool nss_wrapper_hosts_enabled(void);
+ bool socket_wrapper_enabled(void);
+diff --git a/lib/socket/interfaces.c b/lib/socket/interfaces.c
+index ac26b97..f5698f6 100644
+--- a/lib/socket/interfaces.c
++++ b/lib/socket/interfaces.c
+@@ -126,6 +126,10 @@ void make_net(struct sockaddr_storage *pss_out,
+ }
+ 
+ #ifdef HAVE_ETHTOOL
++static inline uint32_t ethtool_cmd_speed(const struct ethtool_cmd *ecmd) {
++  return (ecmd->speed_hi << 16) | ecmd->speed;
++}
++
+ static void query_iface_speed_from_name(const char *name, uint64_t *speed)
+ {
+ 	int ret = 0;
+diff --git a/lib/util/util_pw.c b/lib/util/util_pw.c
+index 8035de4..5d70615 100644
+--- a/lib/util/util_pw.c
++++ b/lib/util/util_pw.c
+@@ -37,7 +37,6 @@ struct passwd *tcopy_passwd(TALLOC_CTX *mem_ctx,
+ 
+ 	len += strlen(from->pw_name)+1;
+ 	len += strlen(from->pw_passwd)+1;
+-	len += strlen(from->pw_gecos)+1;
+ 	len += strlen(from->pw_dir)+1;
+ 	len += strlen(from->pw_shell)+1;
+ 
+@@ -51,7 +50,6 @@ struct passwd *tcopy_passwd(TALLOC_CTX *mem_ctx,
+ 	ret->pw_passwd = talloc_strdup(ret, from->pw_passwd);
+ 	ret->pw_uid = from->pw_uid;
+ 	ret->pw_gid = from->pw_gid;
+-	ret->pw_gecos = talloc_strdup(ret, from->pw_gecos);
+ 	ret->pw_dir = talloc_strdup(ret, from->pw_dir);
+ 	ret->pw_shell = talloc_strdup(ret, from->pw_shell);
+ 
+diff --git a/librpc/ndr/util.c b/librpc/ndr/util.c
+index 0eb7eba..c2a2470 100644
+--- a/librpc/ndr/util.c
++++ b/librpc/ndr/util.c
+@@ -20,8 +20,8 @@
+ */
+ 
+ #include "includes.h"
+-#include "../librpc/ndr/libndr.h"
+ #include "system/network.h"
++#include "../librpc/ndr/libndr.h"
+ #include "lib/util/util_net.h"
+ 
+ _PUBLIC_ void ndr_print_sockaddr_storage(struct ndr_print *ndr, const char *name, const struct sockaddr_storage *ss)
+diff --git a/nsswitch/libwbclient/wbc_pwd.c b/nsswitch/libwbclient/wbc_pwd.c
+index 805ab63..8484194 100644
+--- a/nsswitch/libwbclient/wbc_pwd.c
++++ b/nsswitch/libwbclient/wbc_pwd.c
+@@ -46,7 +46,6 @@ static void wbcPasswdDestructor(void *ptr)
+ 	struct passwd *pw = (struct passwd *)ptr;
+ 	free(pw->pw_name);
+ 	free(pw->pw_passwd);
+-	free(pw->pw_gecos);
+ 	free(pw->pw_shell);
+ 	free(pw->pw_dir);
+ }
+@@ -68,10 +67,6 @@ static struct passwd *copy_passwd_entry(struct winbindd_pw *p)
+ 	if (pw->pw_passwd == NULL) {
+ 		goto fail;
+ 	}
+-	pw->pw_gecos = strdup(p->pw_gecos);
+-	if (pw->pw_gecos == NULL) {
+-		goto fail;
+-	}
+ 	pw->pw_shell = strdup(p->pw_shell);
+ 	if (pw->pw_shell == NULL) {
+ 		goto fail;
+diff --git a/nsswitch/libwbclient/wbc_sid.c b/nsswitch/libwbclient/wbc_sid.c
+index aab96cf..6fed2d9 100644
+--- a/nsswitch/libwbclient/wbc_sid.c
++++ b/nsswitch/libwbclient/wbc_sid.c
+@@ -1054,7 +1054,7 @@ wbcErr wbcCtxGetDisplayName(struct wbcContext *ctx,
+ 
+ 		wbcFreeMemory(name);
+ 
+-		name = wbcStrDup(pwd->pw_gecos);
++		name = wbcStrDup(pwd->pw_name);
+ 		wbcFreeMemory(pwd);
+ 		BAIL_ON_PTR_ERROR(name, wbc_status);
+ 	}
+diff --git a/nsswitch/winbind_struct_protocol.h b/nsswitch/winbind_struct_protocol.h
+index 4a5255c..11fcc4e 100644
+--- a/nsswitch/winbind_struct_protocol.h
++++ b/nsswitch/winbind_struct_protocol.h
+@@ -23,6 +23,10 @@ typedef char fstring[FSTRING_LEN];
+ #ifndef _WINBINDD_NTDOM_H
+ #define _WINBINDD_NTDOM_H
+ 
++#ifdef pw_gecos
++#undef pw_gecos
++#endif
++
+ #define WINBINDD_SOCKET_NAME "pipe"            /* Name of PF_UNIX socket */
+ 
+ /* We let the build environment set the public winbindd socket
+diff --git a/source3/lib/dumpcore.c b/source3/lib/dumpcore.c
+index 0c91206..fa7908e 100644
+--- a/source3/lib/dumpcore.c
++++ b/source3/lib/dumpcore.c
+@@ -319,7 +319,7 @@ void dump_core_setup(const char *progname, const char *log_file)
+ 		}
+ 	}
+ 
+-	umask(~(0700));
++	umask(077);
+ 	dbgflush();
+ 
+ #if defined(HAVE_PRCTL) && defined(PR_SET_DUMPABLE)
+diff --git a/source3/lib/username.c b/source3/lib/username.c
+index f69d9c3..3d44129 100644
+--- a/source3/lib/username.c
++++ b/source3/lib/username.c
+@@ -157,6 +157,8 @@ static struct passwd *Get_Pwnam_internals(TALLOC_CTX *mem_ctx,
+ done:
+ 	DEBUG(5,("Get_Pwnam_internals %s find user [%s]!\n",ret ?
+ 		 "did":"didn't", user));
++	/* if(ret)
++		DEBUG(5,("Get struct passwd: [%s:%s:%ld:%ld:%s:%s:%s]\n", ret->pw_name ? ret->pw_name : "pw_name == NULL", ret->pw_passwd ? ret->pw_passwd : "pw_passwd == NULL", (long) ret->pw_uid, (long) ret->pw_gid, ret->pw_gecos ? ret->pw_gecos : "pw_gecos == NULL", ret->pw_dir ? ret->pw_dir : "pw_dir == NULL", ret->pw_shell ? ret->pw_shell : "pw_shell == NULL")); */
+ 
+ 	return ret;
+ }
+diff --git a/source3/passdb/passdb.c b/source3/passdb/passdb.c
+index 8ed1baf..a66b646 100644
+--- a/source3/passdb/passdb.c
++++ b/source3/passdb/passdb.c
+@@ -115,6 +115,7 @@ static int count_commas(const char *str)
+ {
+ 	int num_commas = 0;
+ 	const char *comma = str;
++	if (!str) return 0;
+ 
+ 	while ((comma = strchr(comma, ',')) != NULL) {
+ 		comma += 1;
+diff --git a/source4/lib/socket/socket.c b/source4/lib/socket/socket.c
+index d7535bf..d54baa6 100644
+--- a/source4/lib/socket/socket.c
++++ b/source4/lib/socket/socket.c
+@@ -20,9 +20,9 @@
+ */
+ 
+ #include "includes.h"
++#include "system/network.h"
+ #include "lib/socket/socket.h"
+ #include "system/filesys.h"
+-#include "system/network.h"
+ #include "param/param.h"
+ #include "../lib/tsocket/tsocket.h"
+ #include "lib/util/util_net.h"
+-- 
+2.25.1
+

--- a/packages/samba/0006-add-berserker.-c-h.patch
+++ b/packages/samba/0006-add-berserker.-c-h.patch
@@ -1,0 +1,280 @@
+From 5131708f0337fc90b03dad4d180f571c973d07c6 Mon Sep 17 00:00:00 2001
+From: Faheem Pervez <trippin1@gmail.com>
+Date: Thu, 18 Jun 2020 11:51:38 +0000
+Subject: [PATCH 6/6] add berserker.{c,h}
+
+The idea of berserker.c is to define missing functions: 
+wrapping getpwnam etc. to return only a root entry, 
+giving any user added to Samba full access.
+
+getpasswd_wrapper is from JimmyChingala:
+https://forum.xda-developers.com/showpost.php?p=8239139&postcount=128
+
+The original berserker.c can be found here,
+from Berserker's port for SambaDroid:
+https://github.com/berserker/android_samba
+
+elliott10 updated it for Samba 4:
+https://github.com/elliott10/samba-4.5.1
+
+I've made the following changes:
+* Use Termux values for root user
+* _Naively_ (really - I know volatile won't help much) prevent
+  getpwent inf. loops
+* Wrap getgrnam and getgrgid, thanks
+  https://blog.csdn.net/jk198310/article/details/15809341
+* Add a couple o' more Android groups
+---
+ source3/include/berserker.c | 148 ++++++++++++++++++++++++++++++++++++
+ source3/include/berserker.h |  51 +++++++++++++
+ source3/include/includes.h  |   1 +
+ source3/wscript_build       |   2 +
+ 4 files changed, 202 insertions(+)
+ create mode 100644 source3/include/berserker.c
+ create mode 100644 source3/include/berserker.h
+
+diff --git a/source3/include/berserker.c b/source3/include/berserker.c
+new file mode 100644
+index 0000000..ac75cb7
+--- /dev/null
++++ b/source3/include/berserker.c
+@@ -0,0 +1,147 @@
++#define BERSERKER_USE_ORIG
++#include "includes.h"
++
++#ifndef AID_ROOT
++#define AID_ROOT 0
++#define AID_MEDIA_RW 1023
++#define AID_EVERYBODY 9997
++#endif
++
++//int getpwnam_r(const char* __name, struct passwd* __pwd, char* __buf, size_t __n, struct passwd** __result);
++
++static volatile int getpwent_ok = 1;
++
++static struct group *group_wrapper(gid_t __gid)
++{
++	static char *rootmem[] = {
++		"root",
++		NULL
++	};
++	static struct group rootgr = {
++		"root",
++		"x" /* NULL */,
++		AID_ROOT,
++		rootmem
++	};
++	static char *everybodymem[] = {
++		"everybody",
++		NULL
++	};
++	static struct group everybodygr = {
++		"everybody",
++		"x" /* NULL */,
++		AID_EVERYBODY,
++		everybodymem
++	};
++	static char *mediarwmem[] = {
++		"media_rw",
++		NULL
++	};
++	static struct group mediarwgr = {
++		"media_rw",
++		"x" /* NULL */,
++		AID_MEDIA_RW,
++		mediarwmem
++	};
++
++	if (__gid == AID_EVERYBODY)
++		return &everybodygr;
++	if (__gid == AID_MEDIA_RW)
++		return &mediarwgr;
++	return &rootgr;
++}
++
++static struct passwd *getpasswd_wrapper()
++{
++#if 0 /* Inconsistencies abound... */
++	static struct passwd pwd;
++	static struct passwd *result = NULL;
++	static char *buf = NULL;
++
++	if (!result) {
++		size_t bufsize;
++		memset(&pwd, 0, sizeof(pwd));
++
++		bufsize = sysconf(_SC_GETPW_R_SIZE_MAX);
++		if (bufsize == -1)
++			bufsize = 16384;
++
++		buf = malloc(bufsize);
++		if (buf == NULL)
++			return NULL;
++
++		(void) getpwnam_r("root", &pwd, buf, bufsize, &result);
++		if (!result) {
++			free(buf);
++			return NULL;
++		}
++
++		if (!pwd.pw_passwd || pwd.pw_passwd[0] == '*')
++			pwd.pw_passwd = "x";
++	}
++
++	return result;
++#else
++	static struct passwd pw = {
++		.pw_name = "root",
++		.pw_passwd = "x",
++		.pw_uid = AID_ROOT,
++		.pw_gid = AID_ROOT,
++		.pw_dir = "@TERMUX_HOME@",
++		.pw_shell = "@TERMUX_PREFIX@/bin/login"
++	 };
++	return &pw;
++#endif
++}
++
++/* getpwent restituisce il prossimo della lista */
++struct passwd *berserker_getpwnam(const char* __name)
++{
++	(void)__name;
++	return getpasswd_wrapper();
++}
++
++struct passwd *berserker_getpwuid(uid_t __uid)
++{
++	(void)__uid;
++	return getpasswd_wrapper();
++}
++
++/* setpwent resetta la lista per iterare su passwd */
++void berserker_setpwent()
++{
++	getpwent_ok = 1;
++}
++
++/* getpwent restituisce la prossima struttura passwd */
++struct passwd *berserker_getpwent()
++{
++	if (getpwent_ok) {
++		getpwent_ok = 0;
++		return getpasswd_wrapper();
++	}
++
++	return NULL;
++}
++
++/* termina il ciclo di iterazione su passwd */
++void berserker_endpwent()
++{
++	getpwent_ok = 1;
++}
++
++struct group *berserker_getgrnam(const char* __name)
++{
++	if (__name) {
++		if (!strcmp(__name, "everybody"))
++			return group_wrapper(AID_EVERYBODY);
++		if (!strcmp(__name, "media_rw"))
++			return group_wrapper(AID_MEDIA_RW);
++	}
++	return group_wrapper(AID_ROOT);
++}
++
++struct group *berserker_getgrgid(gid_t __gid)
++{
++	return group_wrapper(__gid);
++}
+diff --git a/source3/include/berserker.h b/source3/include/berserker.h
+new file mode 100644
+index 0000000..7882380
+--- /dev/null
++++ b/source3/include/berserker.h
+@@ -0,0 +1,51 @@
++#ifndef __BERSERKER_H__
++#define __BERSERKER_H__
++
++#define _PWD_H_	/* disabilita l'inclusione del file pwd.h sotto android */
++#define _GRP_H_
++
++#include <unistd.h>
++#include <sys/types.h>
++
++struct passwd {
++  char* pw_name;
++  char* pw_passwd;
++  uid_t pw_uid;
++  gid_t pw_gid;
++#ifdef __LP64__
++  char* pw_gecos;
++#endif
++  char* pw_dir;
++  char* pw_shell;
++};
++
++struct group {
++  char* gr_name;
++  char* gr_passwd;
++  gid_t gr_gid;
++  char** gr_mem;
++};
++
++#ifndef BERSERKER_USE_ORIG
++#define getpwnam berserker_getpwnam
++struct passwd *berserker_getpwnam(const char* __name);
++#define getpwuid berserker_getpwuid
++struct passwd *berserker_getpwuid(uid_t __uid);
++#define setpwent berserker_setpwent
++void berserker_setpwent(void);
++#define getpwent berserker_getpwent
++struct passwd *berserker_getpwent(void);
++#define endpwent berserker_endpwent
++void berserker_endpwent(void);
++#define getgrnam berserker_getgrnam
++struct group *berserker_getgrnam(const char* __name);
++#define getgrgid berserker_getgrgid
++struct group *berserker_getgrgid(gid_t __gid);
++#endif
++
++/* fix per defines mancanti di utmp.ut_type */
++#ifndef DEAD_PROCESS
++#define DEAD_PROCESS  8
++#endif
++
++#endif
+diff --git a/source3/include/includes.h b/source3/include/includes.h
+index 2dafc65..6937912 100644
+--- a/source3/include/includes.h
++++ b/source3/include/includes.h
+@@ -20,6 +20,7 @@
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
++#include "berserker.h"
+ #include "../replace/replace.h"
+ 
+ /* make sure we have included the correct config.h */
+diff --git a/source3/wscript_build b/source3/wscript_build
+index 10d9f71..bbe3665 100644
+--- a/source3/wscript_build
++++ b/source3/wscript_build
+@@ -166,6 +166,7 @@ bld.SAMBA3_SUBSYSTEM('pdb',
+                           lib/privileges.c
+                           lib/util_nscd.c
+                           lib/winbind_util.c
++                          include/berserker.c
+                           passdb/pdb_util.c
+                           passdb/pdb_interface.c
+                           passdb/pdb_secrets.c''',
+@@ -392,6 +393,7 @@ bld.SAMBA3_SUBSYSTEM('samba3core',
+                           ../lib/util/debug_s3.c
+                           lib/dumpcore.c
+                           lib/interface.c
++                          include/berserker.c
+                           lib/username.c
+                           lib/smbrun.c
+                           lib/wins_srv.c
+-- 
+2.25.1
+

--- a/packages/samba/build.sh
+++ b/packages/samba/build.sh
@@ -1,0 +1,142 @@
+TERMUX_PKG_HOMEPAGE=https://www.samba.org/
+TERMUX_PKG_DESCRIPTION="SMB/CIFS fileserver"
+TERMUX_PKG_LICENSE="GPL-3.0"
+TERMUX_PKG_VERSION=4.12.3
+TERMUX_PKG_SRCURL=https://download.samba.org/pub/samba/samba-${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=3fadbca4504937820d0d8a34e500a1efdcc35e0c554f05bd0a844916ae528727
+TERMUX_PKG_DEPENDS="libbsd, libcap, libcrypt, libgnutls, libiconv, libicu, libpopt, libtalloc, libtirpc, ncurses, openssl, readline, zlib"
+TERMUX_PKG_BUILD_DEPENDS="e2fsprogs"
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_configure() {
+	:
+}
+
+termux_step_make() {
+	:
+}
+
+termux_step_make_install() {
+	local _auth_modules='auth_server,auth_netlogond,auth_script'
+	local _pdb_modules='pdb_tdbsam,pdb_smbpasswd,pdb_wbc_sam'
+	local _vfs_modules='vfs_fake_perms,!vfs_recycle,!vfs_btrfs,!vfs_glusterfs_fuse'
+	_vfs_modules+=',!vfs_virusfilter,!vfs_linux_xfs_sgid,!vfs_shell_snap,!vfs_expand_msdfs'
+	_vfs_modules+=',!vfs_default_quota,!vfs_audit,!vfs_extd_audit,!vfs_full_audit'
+	_vfs_modules+=',!vfs_worm,!vfs_time_audit,!vfs_media_harmony,!vfs_unityed_media,!vfs_shadow_copy,!vfs_shadow_copy2'
+
+	cd "$TERMUX_PKG_SRCDIR"
+
+	cat <<EOF > cross-answers.txt
+Checking uname sysname type: "Linux"
+Checking uname machine type: "$TERMUX_ARCH"
+Checking uname release type: "dontcare"
+Checking uname version type: "dontcare"
+Checking simple C program: "hello world"
+rpath library support: OK
+-Wl,--version-script support: NO
+Checking getconf LFS_CFLAGS: NO
+Checking for large file support without additional flags: OK
+Checking for -D_FILE_OFFSET_BITS=64: OK
+Checking for -D_LARGE_FILES: OK
+Checking correct behavior of strtoll: NO
+Checking for working strptime: NO
+Checking for C99 vsnprintf: OK
+Checking for HAVE_SHARED_MMAP: OK
+Checking for HAVE_MREMAP: OK
+Checking for HAVE_INCOHERENT_MMAP: NO
+Checking for HAVE_SECURE_MKSTEMP: OK
+Checking value of NSIG: "65"
+Checking value of _NSIG: "65"
+Checking value of SIGRTMAX: "64"
+Checking value of SIGRTMIN: "36"
+Checking for a 64-bit host to support lmdb: OK
+Checking value of GNUTLS_CIPHER_AES_128_CFB8: "29"
+Checking value of GNUTLS_MAC_AES_CMAC_128: "203"
+Checking errno of iconv for illegal multibyte sequence: OK
+Checking for kernel change notify support: OK
+Checking for Linux kernel oplocks: OK
+Checking for kernel share modes: OK
+Checking whether POSIX capabilities are available: OK
+Checking if can we convert from CP850 to UCS-2LE: OK
+Checking if can we convert from UTF-8 to UCS-2LE: OK
+vfs_fileid checking for statfs() and struct statfs.f_fsid: OK
+Checking whether we can use Linux thread-specific credentials: NO
+Checking whether setreuid is available: NO
+Checking whether setresuid is available: NO
+Checking whether seteuid is available: NO
+Checking whether setuidx is available: NO
+Checking whether fcntl locking is available: OK
+Checking whether fcntl lock supports open file description locks: OK
+Checking whether fcntl supports flags to send direct I/O availability signals: OK
+Checking whether fcntl supports setting/geting hints: NO
+Checking for the maximum value of the 'time_t' type: NO
+Checking whether the realpath function allows a NULL argument: OK
+Checking for ftruncate extend: OK
+getcwd takes a NULL argument: OK
+EOF
+
+	USING_SYSTEM_ASN1_COMPILE=1 ASN1_COMPILE=/usr/bin/asn1_compile \
+	USING_SYSTEM_COMPILE_ET=1 COMPILE_ET=/usr/bin/compile_et \
+	./buildtools/bin/waf configure \
+		--jobs="$TERMUX_MAKE_PROCESSES" \
+		--bundled-libraries='!asn1_compile,!compile_et' \
+		--cross-compile \
+		--cross-answers=cross-answers.txt \
+		--enable-fhs \
+		--prefix="$TERMUX_PREFIX" \
+		--sysconfdir="$TERMUX_PREFIX/etc" \
+		--localstatedir="$TERMUX_PREFIX/var" \
+		--sbindir="$TERMUX_PREFIX/bin" \
+		--disable-avahi \
+		--disable-cephfs \
+		--disable-cups \
+		--disable-glusterfs \
+		--disable-iprint \
+		--disable-python \
+		--nopyc \
+		--nopyo \
+		--disable-rpath \
+		--disable-rpath-install \
+		--disable-spotlight \
+		--without-acl-support \
+		--without-ad-dc \
+		--without-ads \
+		--without-automount \
+		--without-dmapi \
+		--without-dnsupdate \
+		--without-fam \
+		--without-gettext \
+		--with-gpfs=/dev/null \
+		--without-gpgme \
+		--without-json \
+		--without-ldap \
+		--without-ldb-lmdb \
+		--without-libarchive \
+		--without-lttng \
+		--without-ntvfs-fileserver \
+		--without-pam \
+		--without-quotas \
+		--without-regedit \
+		--without-systemd \
+		--without-utmp \
+		--without-winbind \
+		--with-shared-modules="${_vfs_modules},${_pdb_modules},${_auth_modules}" \
+		--with-static-modules='!auth_winbind'
+		# --disable-fault-handling \
+		# --disable-rpath-private-install \
+		# --with-logfilebase="$TERMUX_PREFIX/tmp/log/samba" \
+
+	./buildtools/bin/waf install --jobs="$TERMUX_MAKE_PROCESSES"
+
+	install -Dm600 "$TERMUX_PKG_BUILDER_DIR/smb.conf.example" "$TERMUX_PREFIX/share/doc/samba/smb.conf.example"
+}
+
+termux_step_post_massage() {
+	# keep empty dirs which were deleted in massage
+	mkdir -p "$TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/var/lib/samba/bind-dns" "$TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/var/lib/samba/private"
+	for dir in cache lock log run; do
+		mkdir -p "$TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/var/$dir/samba"
+	done
+	# 755 - as opposed to 700 - because testparm throws up a warning otherwise
+	chmod 755 "$TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/var/lock/samba" "$TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/var/lib/samba" "$TERMUX_PKG_MASSAGEDIR/$TERMUX_PREFIX/var/cache/samba"
+}

--- a/packages/samba/krb-link-already-defined.patch
+++ b/packages/samba/krb-link-already-defined.patch
@@ -1,0 +1,12 @@
+diff --git a/source4/heimdal_build/et_compile_wrapper.sh b/source4/heimdal_build/et_compile_wrapper.sh
+index 939b434..84f8615 100755
+--- a/source4/heimdal_build/et_compile_wrapper.sh
++++ b/source4/heimdal_build/et_compile_wrapper.sh
+@@ -43,6 +43,7 @@ cd "${DESTDIR}" && {
+ 	mv "${SOURCE}" "${TMP}" && {
+ 		echo "#include \"config.h\"" > "${SOURCE}" && {
+ 			cat "${TMP}" >> "${SOURCE}"
++			sed -i 's/link/link_et/g' "${SOURCE}" || :
+ 		}
+ 	}
+ 	rm -f "${TMP}"

--- a/packages/samba/more-pw_gecos-removal.patch
+++ b/packages/samba/more-pw_gecos-removal.patch
@@ -1,0 +1,118 @@
+diff --git a/nsswitch/wbinfo.c b/nsswitch/wbinfo.c
+index ae89f87..6b4eb7a 100644
+--- a/nsswitch/wbinfo.c
++++ b/nsswitch/wbinfo.c
+@@ -180,7 +180,7 @@ static bool wbinfo_get_userinfo(char *user)
+ 		 pwd->pw_passwd,
+ 		 (unsigned int)pwd->pw_uid,
+ 		 (unsigned int)pwd->pw_gid,
+-		 pwd->pw_gecos,
++		 pwd->pw_name,
+ 		 pwd->pw_dir,
+ 		 pwd->pw_shell);
+ 
+@@ -207,7 +207,7 @@ static bool wbinfo_get_uidinfo(int uid)
+ 		 pwd->pw_passwd,
+ 		 (unsigned int)pwd->pw_uid,
+ 		 (unsigned int)pwd->pw_gid,
+-		 pwd->pw_gecos,
++		 pwd->pw_name,
+ 		 pwd->pw_dir,
+ 		 pwd->pw_shell);
+ 
+@@ -235,7 +235,7 @@ static bool wbinfo_get_user_sidinfo(const char *sid_str)
+ 		 pwd->pw_passwd,
+ 		 (unsigned int)pwd->pw_uid,
+ 		 (unsigned int)pwd->pw_gid,
+-		 pwd->pw_gecos,
++		 pwd->pw_name,
+ 		 pwd->pw_dir,
+ 		 pwd->pw_shell);
+ 
+diff --git a/nsswitch/winbind_nss_linux.c b/nsswitch/winbind_nss_linux.c
+index 635813c..0c69bb9 100644
+--- a/nsswitch/winbind_nss_linux.c
++++ b/nsswitch/winbind_nss_linux.c
+@@ -201,19 +201,6 @@ static NSS_STATUS fill_pwent(struct passwd *result,
+ 	result->pw_uid = pw->pw_uid;
+ 	result->pw_gid = pw->pw_gid;
+ 
+-	/* GECOS */
+-	len = strlen(pw->pw_gecos) + 1;
+-
+-	if ((result->pw_gecos =
+-	     get_static(buffer, buflen, len)) == NULL) {
+-
+-		/* Out of memory */
+-
+-		return NSS_STATUS_TRYAGAIN;
+-	}
+-
+-	memcpy(result->pw_gecos, pw->pw_gecos, len);
+-
+ 	/* Home directory */
+ 	len = strlen(pw->pw_dir) + 1;
+ 
+diff --git a/source3/passdb/passdb.c b/source3/passdb/passdb.c
+index a66b646..15c1251 100644
+--- a/source3/passdb/passdb.c
++++ b/source3/passdb/passdb.c
+@@ -148,21 +148,10 @@ static NTSTATUS samu_set_unix_internal(struct pdb_methods *methods,
+ 
+ 	fullname = NULL;
+ 
+-	if (count_commas(pwd->pw_gecos) == 3) {
+-		/*
+-		 * Heuristic: This seems to be a gecos field that has been
+-		 * edited by chfn(1). Only use the part before the first
+-		 * comma. Fixes bug 5198.
+-		 */
+-		fullname = talloc_strndup(
+-			talloc_tos(), pwd->pw_gecos,
+-			strchr(pwd->pw_gecos, ',') - pwd->pw_gecos);
+-	}
+-
+ 	if (fullname != NULL) {
+ 		pdb_set_fullname(user, fullname, PDB_SET);
+ 	} else {
+-		pdb_set_fullname(user, pwd->pw_gecos, PDB_SET);
++		pdb_set_fullname(user, pwd->pw_name, PDB_SET);
+ 	}
+ 	TALLOC_FREE(fullname);
+ 
+diff --git a/source3/winbindd/wb_getpwsid.c b/source3/winbindd/wb_getpwsid.c
+index 8dc09eb..52d1ecc 100644
+--- a/source3/winbindd/wb_getpwsid.c
++++ b/source3/winbindd/wb_getpwsid.c
+@@ -116,9 +116,6 @@ static void wb_getpwsid_queryuser_done(struct tevent_req *subreq)
+ 
+ 	strlcpy(pw->pw_name, output_username, sizeof(pw->pw_name));
+ 
+-	strlcpy(pw->pw_gecos, info->full_name ? info->full_name : "",
+-		sizeof(pw->pw_gecos));
+-
+ 	tmp = talloc_sub_specified(
+ 		state, info->homedir, acct_name,
+ 		info->primary_group_name, info->domain_name,
+diff --git a/source4/auth/ntlm/auth_unix.c b/source4/auth/ntlm/auth_unix.c
+index 67cd5f3..bf1bc6d 100644
+--- a/source4/auth/ntlm/auth_unix.c
++++ b/source4/auth/ntlm/auth_unix.c
+@@ -83,7 +83,7 @@ static NTSTATUS authunix_make_user_info_dc(TALLOC_CTX *mem_ctx,
+ 	user_info_dc->user_session_key = data_blob(NULL,0);
+ 	user_info_dc->lm_session_key = data_blob(NULL,0);
+ 
+-	info->full_name = talloc_steal(info, pwd->pw_gecos);
++	info->full_name = talloc_strdup(info, pwd->pw_name); /* XXX: I _think_ talloc_steal here for pw_name would be wrong */
+ 	NT_STATUS_HAVE_NO_MEMORY(info->full_name);
+ 	info->logon_script = talloc_strdup(info, "");
+ 	NT_STATUS_HAVE_NO_MEMORY(info->logon_script);
+@@ -132,8 +132,6 @@ static NTSTATUS talloc_getpwnam(TALLOC_CTX *ctx, const char *username, struct pa
+ 
+         ret->pw_uid = from->pw_uid;
+         ret->pw_gid = from->pw_gid;
+-        ret->pw_gecos = talloc_strdup(ctx, from->pw_gecos);
+-	NT_STATUS_HAVE_NO_MEMORY(ret->pw_gecos);
+ 
+         ret->pw_dir = talloc_strdup(ctx, from->pw_dir);
+ 	NT_STATUS_HAVE_NO_MEMORY(ret->pw_dir);

--- a/packages/samba/openwrt-fix-host-tools-checks.patch
+++ b/packages/samba/openwrt-fix-host-tools-checks.patch
@@ -1,0 +1,40 @@
+--- a/wscript_configure_embedded_heimdal	2019-12-17
++++ b/wscript_configure_embedded_heimdal	2019-12-17
+@@ -1 +1,12 @@
+ conf.RECURSE('source4/heimdal_build')
++
++def check_system_heimdal_binary(name):
++    if conf.LIB_MAY_BE_BUNDLED(name):
++        return False
++    if not conf.find_program(name, var=name.upper()):
++        return False
++    conf.define('USING_SYSTEM_%s' % name.upper(), 1)
++    return True
++
++check_system_heimdal_binary("compile_et")
++check_system_heimdal_binary("asn1_compile")
+--- a/wscript_configure_system_heimdal	2019-12-17
++++ b/wscript_configure_system_heimdal	2019-12-17
+@@ -37,14 +37,6 @@ def check_system_heimdal_lib(name, funct
+     conf.define('USING_SYSTEM_%s' % name.upper(), 1)
+     return True
+ 
+-def check_system_heimdal_binary(name):
+-    if conf.LIB_MAY_BE_BUNDLED(name):
+-        return False
+-    if not conf.find_program(name, var=name.upper()):
+-        return False
+-    conf.define('USING_SYSTEM_%s' % name.upper(), 1)
+-    return True
+-
+ check_system_heimdal_lib("com_err", "com_right_r com_err", "com_err.h")
+ 
+ if check_system_heimdal_lib("roken", "rk_socket_set_reuseaddr", "roken.h"):
+@@ -96,7 +88,4 @@ finally:
+ #if conf.CHECK_BUNDLED_SYSTEM('tommath', checkfunctions='mp_init', headers='tommath.h'):
+ #    conf.define('USING_SYSTEM_TOMMATH', 1)
+ 
+-check_system_heimdal_binary("compile_et")
+-check_system_heimdal_binary("asn1_compile")
+-
+ conf.define('USING_SYSTEM_KRB5', 1)

--- a/packages/samba/smb.conf.example
+++ b/packages/samba/smb.conf.example
@@ -1,0 +1,134 @@
+# vim: filetype=samba
+[global]
+   ; these are very recommended to have, even if maybe superfluous
+   workgroup = WORKGROUP
+   unix password sync = no
+   pam password change = no
+   obey pam restrictions = no
+   passwd program = /system/bin/true
+   add user script = /system/bin/true
+   add group script = /system/bin/true
+   add user to group script = /system/bin/true
+   add machine script = /system/bin/true
+   delete user script = /system/bin/true
+   delete user from group script = /system/bin/true
+   delete group script = /system/bin/true
+   rename user script = /system/bin/true
+   name resolve order = lmhosts host bcast
+   bind interfaces only = yes
+   interfaces = 127.0.0.0/8 wlan0
+
+   ;hosts allow = 192.168.1.5 127.
+   server string = Samba on Termux
+   security = user
+   server role = standalone
+   delete readonly = yes
+   inherit permissions = yes
+
+   ; Make smbd do less and announce nothing
+   ; for automatic discovery, you may need to remove some of these
+   local master = no
+   preferred master = no
+   lm announce = no
+   multicast dns register = no
+   host msdfs = no
+   dns proxy = no
+   allow dns updates = disabled
+   dns update command = /system/bin/false
+   server services = smb
+   dcerpc endpoint servers = rpcecho
+
+   ; if you disable NetBIOS, which enables automatic discovery, 1139 can be removed from smb ports
+   ;disable netbios = yes
+   ; remember: ports < 1024 cannot be bound to by non-root processes
+   ; Windows can only see SMB servers on port 445, so if your phone is rooted
+   ; use iptables to redirect requests for port
+   ; 445 to, say, 4445 (capabilities may work instead. no clue)
+   smb ports = 1139 4445
+   max connections = 6
+   max smbd processes = 8
+   deadtime = 15
+
+   ; disable guest access
+   map to guest = Never
+   restrict anonymous = 2
+
+   ; basic attempt at performance tuning for my phone
+   ; change as necessary for your device
+   ;aio read size = 16384 
+   aio write size = 0
+   use sendfile = yes 
+   min receivefile size = 16384
+   socket options = TCP_NODELAY SO_KEEPALIVE
+   oplocks = yes
+   level2 oplocks = yes
+   kernel oplocks = no
+   strict locking = no
+   max stat cache size = 1024
+
+   ; turn off things that cannot be set on sdcardfs and vfat filesystems
+   nt acl support = no
+   unix extensions = no
+   ea support = no
+   store dos attributes = no
+   map archive = no
+   map hidden = no
+   map readonly = no
+   map system = no
+
+   ;log file = /data/data/com.termux/files/usr/var/log/samba/log.%m
+   ;log level = 0
+   max log size = 50
+   ;logging = syslog
+   ;syslog only = yes
+   ;syslog = 0
+   enable core files = no
+
+   ; disable printing support as much as possible
+   load printers = no
+   printing = bsd
+   printcap name = /dev/null
+   disable spoolss = yes
+   show add printer wizard = no
+   max print jobs = 0
+   lpq command = /system/bin/false
+   lprm command = /system/bin/false
+   print command = /system/bin/false
+
+#============================ Share Definitions ==============================
+; remember to run termux-setup-storage first
+[internal]
+   comment = Internal storage
+   path = @TERMUX_HOME@/storage/shared
+   vfs objects = aio_pthread
+   aio_pthread:aio open = yes
+   read only = no
+   browseable = no
+   writable = yes
+   guest ok = no
+; these are commented because it seems they're assumed on Android anyway
+;   force user = root
+;   force group = everybody
+;   create mask = 0660
+;   force create mode = 0660
+;   directory mask = 0770
+;   force directory mode = 0770
+;   vfs objects = fake_perms
+
+; replace /storage/ext_sd with the path to your external card in /storage
+; because of the way Android works, you cannot have write access
+; to external storage unless you're running a custom ROM or have
+; the Magisk module that enables it installed
+;[external]
+;   comment = microSD
+;   path = /storage/ext_sd
+;   vfs objects = aio_pthread
+;   aio_pthread:aio open = yes
+;   read only = yes
+;   browseable = no
+;   writable = yes
+;   guest ok = no
+;   fstype = FAT
+;;   force group = media_rw
+;;   create mask = 0770
+;;   force create mode = 0770


### PR DESCRIPTION
(~~The termux-packages submodule in this repository needs updating first - libtirrpc is missing from termux-packages, I didn't know to do it properly.~~ Thanks Grimler91 :) `libparse-yapp-perl heimdal-multidev comerr-dev` needs to be installed in the Ubuntu build host - they're all present in `setup_ubuntu.sh`.)

* I've tested Samba builds for 32-bit ARM, as well as 64-bit ARM, but I've not tested it on a 32-bit ARM device. Works fine on my 64-bit phone, though.

    * Android 32-bit ARM doesn't have a `pw_gecos` field in the passwd struct. All the salient references to it have been patched out. 

* I've noticed on a couple of occasions that if left running uninterrupted for two days, `smbd`'s CPU usage can skyrocket to a continuous 100%

* I've only tested `smbd`, the part of Samba that actually serves up files, and `testparm`. I've not tested `nmbd`, which announces your device's presence over NetBIOS, at all.

* Running this on a rooted phone would be best. Windows will only connect to SMB servers on port 445, a number certainly lower than 1024. 
That's not to say this is entirely useless if not rooted, however: you can `adb forward` port 4445 on your phone to 445 on a Windows loopback adapter, allowing you to access your shares over USB. This allows you to open large files from your phone without needing to copy the file in its entirety to your PC - this was my impetus for looking into all this in the first place. 
Write access to your external SD card can be achieved if rooted by installing a Magisk module that enables that.

* This package installs a sample smbd.conf to `$PREFIX/share/doc/samba/smb.conf.example`, which can be copied by the user into `$PREFIX/etc/samba/smb.conf`. This smb.conf is what I use; however, the settings disabling encryption have been taken out. My smb.conf is very opinionated  and disables things people may prefer to have on. 

* Samba thinks the only UNIX user account that actually exists is root. As such, any Samba account created will map to root. This is fine to me because Termux is a single-user system anyway. This had to be done because with any account not root, Samba will throw up errors about permissions and disallow browsing and writing to shares, even if the user account `smbd` is running under has permissions to read and write.

    * This is achieved by using berserker's berserker.c to override `getpwnam` etc. While Samba has username mapping functionality built in, API 24 lacks some password functions that Samba requires anyway, so it was easier to continue using  berserker.c 

    * This may or may not cause problems with permissions if sharing, say, your Termux home directory. I don't actually know and nor have I tested as I use SFTP for everything else

* The WAF cross-compile answers come from my S10 running Android 9 with kernel 4.14.154

All I do after installing is add a user account for Samba: `smbpasswd -L -a $(id -un)`

---

<details><summary>My script to start `smbd`</summary>
<p>

This takes care of setting up logging to Termux's tmp directory, adding an iptables rule to redirect 445 to 4445, bumping up the allowed number of open files and cleaning up the files left on exit.

```
#!/data/data/com.termux/files/usr/bin/dash
# vim: filetype=sh
: "${PREFIX:=/data/data/com.termux/files/usr}"
: "${TMPDIR:=$PREFIX/tmp}"
SVC_DAEMON="$PREFIX/bin/smbd"
PID_DIR="$PREFIX/var/run/samba"
SMBD_PID_FILE="$PID_DIR/smbd.pid"

start() {
	local log_dir="$PREFIX/tmp/log/samba"
	local iptargs='PREROUTING -t nat -p tcp --dport 445 -j REDIRECT --to-port 4445'

	mkdir -p "$log_dir" "$PID_DIR"
	su -c "/system/bin/iptables -C $iptargs 2>/dev/null || /system/bin/iptables -A $iptargs"
	su -c "$PREFIX/bin/prlimit" --pid $$ --nofile=65536:65536
	#[ "$(testparm -s --parameter-name='enable core files' 2>/dev/null)" = Yes ] && su -c "$PREFIX/bin/prlimit" --pid $$ --core=unlimited:unlimited

	exec start-stop-daemon --start --quiet --oknodo --exec "$SVC_DAEMON" --pidfile "$SMBD_PID_FILE" --nicelevel -4 -- --foreground --option='max open files=65536' --log-stdout --log-basename="$log_dir" >/dev/null 2>&1
}

stop() {
	local smbd_pid
	if [ -f "$SMBD_PID_FILE" ]; then 
		read -r smbd_pid < "$SMBD_PID_FILE"
		rm -f "$SMBD_PID_FILE"
	fi
	if [ -n "$smbd_pid" ] && [ -d "/proc/$smbd_pid" ]; then
		start-stop-daemon --stop --quiet --pid "$smbd_pid"
	else
		start-stop-daemon --stop --quiet --exec "$SVC_DAEMON"
	fi
	if [ $? -eq 0 ]; then
		sleep 1
	fi
	find "$PREFIX/var/lock/samba/" ! -type d -delete
	find "$PREFIX/var/lib/samba/private/msg.sock/" -type s -exec dash -c 'grep -q "$1" /proc/net/unix || unlink "$1"' _ {} \;
}

case $0 in
	*-stop)
		stop >/dev/null 2>&1
		exit $?
	;;
esac

if test ! -t 0; then
	start
else
	am startservice -n com.termux/com.termux.app.TermuxService -a com.termux.service_execute -d com.termux.file:"$(realpath "$0")" --ez com.termux.execute.background true
fi

```

</p>
</details>

---

<details><summary>Accessing Samba shares over USB on Windows</summary>
<p>

A working ADB connection is required.

1. Set up Windows as per [this](https://www.nikhef.nl/~janjust/CifsOverSSH/Win10Loopback.html). The PuTTY stuff can be skipped.

2. Run adb.exe on your computer like this to have forwarded ports bind to all your PC's interfaces: `adb kill-server & adb -a nodaemon server start`. The Windows Firewall prompts can be cancelled

3. Make sure smbd is running on your phone. I have the following in a batch file to automatically run that script from above (requires a rooted phone):

```
adb shell su -c "'x(){ am startservice -n com.termux/com.termux.app.TermuxService -a com.termux.service_execute -d com.termux.file:\"/data/data/com.termux/files/home/.shortcuts/tasks/smbd-start\" --ez com.termux.execute.background true; } ; x || { magiskpolicy --live \"allow system_server magisk_file sock_file read\" \"allow system_server magisk_file sock_file write\" ; x; }'"
if NOT "%ERRORLEVEL%"=="0" exit /b 1
```

4. Forward the port: `adb forward tcp:44445 tcp:4445`

5. Map the share: `net use Y: \\10.255.255.1\<name of share> <password> /USER:<name of samba user> /PERSISTENT:NO`

</p>
</details>
