### PR TITLE
ghc: update to 8.10.1, build again

### DIFF
--- a/packages/ghc/always-use-pic-on-android-for-dynexec.patch
+++ b/packages/ghc/always-use-pic-on-android-for-dynexec.patch
@@ -1,0 +1,11 @@
+--- ghc-8.10.1/compiler/main/DynFlags.hs.orig	2020-06-13 08:56:50.595808526 +0100
++++ ghc-8.10.1/compiler/main/DynFlags.hs	2020-06-13 08:57:24.770000253 +0100
+@@ -4624,6 +4624,8 @@
+ default_PIC platform =
+   case (platformOS platform, platformArch platform) of
+     (OSDarwin, ArchX86_64) -> [Opt_PIC]
++    (OSLinux, ArchARM64) -> [Opt_PIC]
++    (OSUnknown, ArchARM64) -> [Opt_PIC]
+     (OSOpenBSD, ArchX86_64) -> [Opt_PIC] -- Due to PIE support in
+                                          -- OpenBSD since 5.3 release
+                                          -- (1 May 2013) we need to

--- a/packages/ghc/always_link_m.patch
+++ b/packages/ghc/always_link_m.patch
@@ -1,0 +1,30 @@
+diff --git a/compiler/main/SysTools.hs b/compiler/main/SysTools.hs
+index b3312b0..b0e3d90 100644
+--- a/compiler/main/SysTools.hs
++++ b/compiler/main/SysTools.hs
+@@ -414,11 +414,7 @@ linkDynLib dflags0 o_files dep_packages
+ -- math-y things are used (which we assume to include all programs). See #14022.
+ libmLinkOpts :: [Option]
+ libmLinkOpts =
+-#if defined(HAVE_LIBM)
+   [Option "-lm"]
+-#else
+-  []
+-#endif
+ 
+ getPkgFrameworkOpts :: DynFlags -> Platform -> [InstalledUnitId] -> IO [String]
+ getPkgFrameworkOpts dflags platform dep_packages
+diff --git a/rts/package.conf.in b/rts/package.conf.in
+index e4cb159..7a234cd 100644
+--- a/rts/package.conf.in
++++ b/rts/package.conf.in
+@@ -26,9 +26,7 @@ library-dirs:           TOP"/rts/dist/build" FFI_LIB_DIR LIBDW_LIB_DIR
+ hs-libraries:   "HSrts" FFI_LIB
+ 
+ extra-libraries:
+-#if defined(HAVE_LIBM)
+                                 "m"             /* for ldexp() */
+-#endif
+ #if defined(HAVE_LIBRT)
+                               , "rt"
+ #endif

--- a/packages/ghc/build.sh
+++ b/packages/ghc/build.sh
@@ -35,7 +35,7 @@ termux_step_post_extract_package() {
 	TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --target=${TERMUX_HOST_PLATFORM}"
 }
 
-termux_step_pre_configure () {
+termux_step_pre_configure() {
 	echo "INTEGER_LIBRARY = integer-simple" > mk/build.mk
 	#echo "GhcStage2HcOpts = $ORIG_CFLAGS $ORIG_CPPFLAGS $ORIG_LDFLAGS" >> mk/build.mk
 

--- a/packages/ghc/build.sh
+++ b/packages/ghc/build.sh
@@ -6,7 +6,7 @@ TERMUX_PKG_HOMEPAGE=https://www.haskell.org/ghc/
 TERMUX_PKG_DESCRIPTION="The Glasgow Haskell Compilation system"
 TERMUX_PKG_VERSION=8.0.1
 TERMUX_PKG_SRCURL=http://downloads.haskell.org/~ghc/${TERMUX_PKG_VERSION}/ghc-${TERMUX_PKG_VERSION}-src.tar.xz
-TERMUX_PKG_BUILD_IN_SRC=yes
+TERMUX_PKG_BUILD_IN_SRC=true
 # Depend on clang for now until llvm is split into separate package:
 TERMUX_PKG_DEPENDS="clang, ncurses"
 

--- a/packages/ghc/build.sh
+++ b/packages/ghc/build.sh
@@ -8,6 +8,7 @@ TERMUX_PKG_DEPENDS="binutils, clang, iconv, libffi, llvm, ncurses"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_NO_STATICSPLIT=true
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS=" --disable-ld-override --build=x86_64-unknown-linux --host=x86_64-unknown-linux"
+TERMUX_PKG_BLACKLISTED_ARCHES="arm, i686, x86_64"
 
 DYNAMIC_GHC_PROGRAMS=NO
 

--- a/packages/ghc/build.sh
+++ b/packages/ghc/build.sh
@@ -2,11 +2,6 @@
 #     https://ghc.haskell.org/trac/ghc/wiki/Building/Preparation/Linux
 # and
 #     https://github.com/neurocyte/ghc-android
-#
-# Status: Currently fails at "error: cannot find -lpthread"
-#         right after message about building bin/hpc.
-#         As libpthread does not exist on Android (pthread
-#         is built into libc, this needs to be patched away.
 TERMUX_PKG_HOMEPAGE=https://www.haskell.org/ghc/
 TERMUX_PKG_DESCRIPTION="The Glasgow Haskell Compilation system"
 TERMUX_PKG_VERSION=8.0.1
@@ -18,26 +13,28 @@ TERMUX_PKG_DEPENDS="clang, ncurses"
 
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--with-iconv-includes=$TERMUX_PREFIX/include -with-iconv-libraries=$TERMUX_PREFIX/lib"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --with-curses-includes=$TERMUX_PREFIX/include/ncursesw -with-curses-libraries=$TERMUX_PREFIX/lib"
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --host=${TERMUX_HOST_PLATFORM}"
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --target=${TERMUX_HOST_PLATFORM}"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --host=x86_64-unknown-linux --build=x86_64-unknown-linux"
 
-ORIG_CFLAGS="$CFLAGS"
-ORIG_CPPFLAGS="$CPPFLAGS"
-ORIG_LDFLAGS="$LDFLAGS"
+termux_step_post_extract_package() {
+	ORIG_CFLAGS="$CFLAGS"
+	ORIG_CPPFLAGS="$CPPFLAGS"
+	ORIG_LDFLAGS="$LDFLAGS"
 
-unset AR
-unset AS
-unset CC
-export CFLAGS=""
-unset CPP
-export CPPFLAGS=""
-unset CXXFLAGS
-unset CXX
-export LDFLAGS=""
-unset LD
-unset PKG_CONFIG
-unset RANLIB
+	unset AR
+	unset AS
+	unset CC
+	export CFLAGS=""
+	unset CPP
+	export CPPFLAGS=""
+	unset CXXFLAGS
+	unset CXX
+	export LDFLAGS=""
+	unset LD
+	unset PKG_CONFIG
+	unset RANLIB
+
+	TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --target=${TERMUX_HOST_PLATFORM}"
+}
 
 termux_step_pre_configure () {
 	echo "INTEGER_LIBRARY = integer-simple" > mk/build.mk

--- a/packages/ghc/build.sh
+++ b/packages/ghc/build.sh
@@ -1,5 +1,9 @@
 # See https://ghc.haskell.org/trac/ghc/wiki/Building/CrossCompiling
 #     https://ghc.haskell.org/trac/ghc/wiki/Building/Preparation/Linux
+# and
+#     https://github.com/neurocyte/ghc-android
+# Currently fails with:
+#     "Can't use -fPIC or -dynamic on this platform"
 TERMUX_PKG_HOMEPAGE=https://www.haskell.org/ghc/
 TERMUX_PKG_DESCRIPTION="The Glasgow Haskell Compilation system"
 TERMUX_PKG_VERSION=7.10.2

--- a/packages/ghc/build.sh
+++ b/packages/ghc/build.sh
@@ -1,0 +1,35 @@
+# See https://ghc.haskell.org/trac/ghc/wiki/Building/CrossCompiling
+#     https://ghc.haskell.org/trac/ghc/wiki/Building/Preparation/Linux
+TERMUX_PKG_HOMEPAGE=https://www.haskell.org/ghc/
+TERMUX_PKG_DESCRIPTION="The Glasgow Haskell Compilation system"
+TERMUX_PKG_VERSION=7.10.2
+TERMUX_PKG_SRCURL=http://downloads.haskell.org/~ghc/${TERMUX_PKG_VERSION}/ghc-${TERMUX_PKG_VERSION}-src.tar.xz
+TERMUX_PKG_FOLDERNAME=ghc-$TERMUX_PKG_VERSION
+TERMUX_PKG_BUILD_IN_SRC=yes
+# TERMUX_PKG_DEPENDS="libandroid-support"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--with-target=$TERMUX_HOST_PLATFORM --host=x86_64-unknown-linux --build=x86_64-unknown-linux --target=$TERMUX_HOST_PLATFORM"
+
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --with-iconv-includes=$TERMUX_PREFIX/include -with-iconv-libraries=$TERMUX_PREFIX/lib"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --with-curses-includes=$TERMUX_PREFIX/include/ncursesw -with-curses-libraries=$TERMUX_PREFIX/lib"
+
+ORIG_CFLAGS="$CFLAGS"
+ORIG_CPPFLAGS="$CPPFLAGS"
+ORIG_LDFLAGS="$LDFLAGS"
+
+unset AR
+unset AS
+unset CC
+export CFLAGS=""
+unset CPP
+export CPPFLAGS=""
+unset CXXFLAGS
+unset CXX
+export LDFLAGS=""
+unset LD
+unset PKG_CONFIG
+unset RANLIB
+
+termux_step_pre_configure () {
+	echo "GhcStage2HcOpts = $ORIG_CFLAGS $ORIG_CPPFLAGS $ORIG_LDFLAGS" > mk/build.mk
+	echo "INTEGER_LIBRARY = integer-simple" >> mk/build.mk
+}

--- a/packages/ghc/build.sh
+++ b/packages/ghc/build.sh
@@ -31,7 +31,7 @@ termux_step_pre_configure() {
 	GhcStage2HcOpts += -optl-Wl,--enable-new-dtags
 	INTEGER_LIBRARY = integer-simple
 	SplitSections   = YES
-	BuildFlavour         = perf-cross
+	BuildFlavour         = quick-cross
 	HADDOCK_DOCS         = NO
 	BUILD_SPHINX_HTML    = NO
 	BUILD_SPHINX_PS      = NO

--- a/packages/ghc/build.sh
+++ b/packages/ghc/build.sh
@@ -2,20 +2,22 @@
 #     https://ghc.haskell.org/trac/ghc/wiki/Building/Preparation/Linux
 # and
 #     https://github.com/neurocyte/ghc-android
-# Status: Current GHC supports llvm 3.7, but look at
-#         https://github.com/erikd/ghc-llvm-next
-#         for building against llvm 3.8.
+#
+# Status: Currently fails at "error: cannot find -lpthread"
+#         right after message about building bin/hpc.
+#         As libpthread does not exist on Android (pthread
+#         is built into libc, this needs to be patched away.
 TERMUX_PKG_HOMEPAGE=https://www.haskell.org/ghc/
 TERMUX_PKG_DESCRIPTION="The Glasgow Haskell Compilation system"
 TERMUX_PKG_VERSION=8.0.1
 TERMUX_PKG_SRCURL=http://downloads.haskell.org/~ghc/${TERMUX_PKG_VERSION}/ghc-${TERMUX_PKG_VERSION}-src.tar.xz
 TERMUX_PKG_FOLDERNAME=ghc-$TERMUX_PKG_VERSION
 TERMUX_PKG_BUILD_IN_SRC=yes
-# TERMUX_PKG_DEPENDS="libandroid-support"
+# Depend on clang for now until llvm is split into separate package:
+TERMUX_PKG_DEPENDS="clang, ncurses"
 
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--with-iconv-includes=$TERMUX_PREFIX/include -with-iconv-libraries=$TERMUX_PREFIX/lib"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --with-curses-includes=$TERMUX_PREFIX/include/ncursesw -with-curses-libraries=$TERMUX_PREFIX/lib"
-# FIXME: This triplet is not known to compiler/llvmGen/LlvmCodeGen/Ppr.hs:
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --host=${TERMUX_HOST_PLATFORM}"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --target=${TERMUX_HOST_PLATFORM}"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --host=x86_64-unknown-linux --build=x86_64-unknown-linux"

--- a/packages/ghc/build.sh
+++ b/packages/ghc/build.sh
@@ -6,7 +6,6 @@ TERMUX_PKG_HOMEPAGE=https://www.haskell.org/ghc/
 TERMUX_PKG_DESCRIPTION="The Glasgow Haskell Compilation system"
 TERMUX_PKG_VERSION=8.0.1
 TERMUX_PKG_SRCURL=http://downloads.haskell.org/~ghc/${TERMUX_PKG_VERSION}/ghc-${TERMUX_PKG_VERSION}-src.tar.xz
-TERMUX_PKG_FOLDERNAME=ghc-$TERMUX_PKG_VERSION
 TERMUX_PKG_BUILD_IN_SRC=yes
 # Depend on clang for now until llvm is split into separate package:
 TERMUX_PKG_DEPENDS="clang, ncurses"

--- a/packages/ghc/build.sh
+++ b/packages/ghc/build.sh
@@ -2,18 +2,23 @@
 #     https://ghc.haskell.org/trac/ghc/wiki/Building/Preparation/Linux
 # and
 #     https://github.com/neurocyte/ghc-android
-# Status: Current GHC does not support llvm 3.7.
+# Status: Current GHC supports llvm 3.7, but look at
+#         https://github.com/erikd/ghc-llvm-next
+#         for building against llvm 3.8.
 TERMUX_PKG_HOMEPAGE=https://www.haskell.org/ghc/
 TERMUX_PKG_DESCRIPTION="The Glasgow Haskell Compilation system"
-TERMUX_PKG_VERSION=7.10.2
+TERMUX_PKG_VERSION=8.0.1
 TERMUX_PKG_SRCURL=http://downloads.haskell.org/~ghc/${TERMUX_PKG_VERSION}/ghc-${TERMUX_PKG_VERSION}-src.tar.xz
 TERMUX_PKG_FOLDERNAME=ghc-$TERMUX_PKG_VERSION
 TERMUX_PKG_BUILD_IN_SRC=yes
 # TERMUX_PKG_DEPENDS="libandroid-support"
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--with-target=$TERMUX_HOST_PLATFORM --host=x86_64-unknown-linux --build=x86_64-unknown-linux --target=$TERMUX_HOST_PLATFORM"
 
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --with-iconv-includes=$TERMUX_PREFIX/include -with-iconv-libraries=$TERMUX_PREFIX/lib"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--with-iconv-includes=$TERMUX_PREFIX/include -with-iconv-libraries=$TERMUX_PREFIX/lib"
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --with-curses-includes=$TERMUX_PREFIX/include/ncursesw -with-curses-libraries=$TERMUX_PREFIX/lib"
+# FIXME: This triplet is not known to compiler/llvmGen/LlvmCodeGen/Ppr.hs:
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --host=${TERMUX_HOST_PLATFORM}"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --target=${TERMUX_HOST_PLATFORM}"
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --host=x86_64-unknown-linux --build=x86_64-unknown-linux"
 
 ORIG_CFLAGS="$CFLAGS"
 ORIG_CPPFLAGS="$CPPFLAGS"
@@ -38,5 +43,7 @@ termux_step_pre_configure () {
 
 	# Avoid "Can't use -fPIC or -dynamic on this platform":
 	echo "DYNAMIC_GHC_PROGRAMS = NO" >> mk/build.mk
-	echo "GhcLibWays = v" >> mk/build.m
+	echo "GhcLibWays = v" >> mk/build.mk
+	# "Can not build haddock docs when CrossCompiling or Stage1Only".
+	echo "HADDOCK_DOCS=NO" >> mk/build.mk
 }

--- a/packages/ghc/build.sh
+++ b/packages/ghc/build.sh
@@ -2,8 +2,7 @@
 #     https://ghc.haskell.org/trac/ghc/wiki/Building/Preparation/Linux
 # and
 #     https://github.com/neurocyte/ghc-android
-# Currently fails with:
-#     "Can't use -fPIC or -dynamic on this platform"
+# Status: Current GHC does not support llvm 3.7.
 TERMUX_PKG_HOMEPAGE=https://www.haskell.org/ghc/
 TERMUX_PKG_DESCRIPTION="The Glasgow Haskell Compilation system"
 TERMUX_PKG_VERSION=7.10.2
@@ -34,6 +33,10 @@ unset PKG_CONFIG
 unset RANLIB
 
 termux_step_pre_configure () {
-	echo "GhcStage2HcOpts = $ORIG_CFLAGS $ORIG_CPPFLAGS $ORIG_LDFLAGS" > mk/build.mk
-	echo "INTEGER_LIBRARY = integer-simple" >> mk/build.mk
+	echo "INTEGER_LIBRARY = integer-simple" > mk/build.mk
+	#echo "GhcStage2HcOpts = $ORIG_CFLAGS $ORIG_CPPFLAGS $ORIG_LDFLAGS" >> mk/build.mk
+
+	# Avoid "Can't use -fPIC or -dynamic on this platform":
+	echo "DYNAMIC_GHC_PROGRAMS = NO" >> mk/build.mk
+	echo "GhcLibWays = v" >> mk/build.m
 }

--- a/packages/ghc/build.sh
+++ b/packages/ghc/build.sh
@@ -4,14 +4,16 @@ TERMUX_PKG_LICENSE="custom"
 TERMUX_PKG_VERSION=8.10.1
 TERMUX_PKG_SRCURL=http://downloads.haskell.org/~ghc/${TERMUX_PKG_VERSION}/ghc-${TERMUX_PKG_VERSION}-src.tar.xz
 TERMUX_PKG_SHA256=4e3b07f83a266b3198310f19f71e371ebce97c769b14f0d688f4cbf2a2a1edf5
-TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_DEPENDS="binutils, clang, iconv, libffi, llvm, ncurses"
+TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_NO_STATICSPLIT=true
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS=" --disable-ld-override --build=x86_64-unknown-linux --host=x86_64-unknown-linux"
 
 DYNAMIC_GHC_PROGRAMS=NO
 
 termux_step_pre_configure() {
+	termux_setup_ghc
+
 	TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --target=${TERMUX_HOST_PLATFORM}"
 
 	# After stage 0, cabal passes a host string to the libraries' configure scripts that isn't valid.

--- a/packages/ghc/build.sh
+++ b/packages/ghc/build.sh
@@ -1,23 +1,76 @@
-# See https://ghc.haskell.org/trac/ghc/wiki/Building/CrossCompiling
-#     https://ghc.haskell.org/trac/ghc/wiki/Building/Preparation/Linux
-# and
-#     https://github.com/neurocyte/ghc-android
 TERMUX_PKG_HOMEPAGE=https://www.haskell.org/ghc/
 TERMUX_PKG_DESCRIPTION="The Glasgow Haskell Compilation system"
-TERMUX_PKG_VERSION=8.0.1
+TERMUX_PKG_LICENSE="custom"
+TERMUX_PKG_VERSION=8.10.1
 TERMUX_PKG_SRCURL=http://downloads.haskell.org/~ghc/${TERMUX_PKG_VERSION}/ghc-${TERMUX_PKG_VERSION}-src.tar.xz
+TERMUX_PKG_SHA256=4e3b07f83a266b3198310f19f71e371ebce97c769b14f0d688f4cbf2a2a1edf5
 TERMUX_PKG_BUILD_IN_SRC=true
-# Depend on clang for now until llvm is split into separate package:
-TERMUX_PKG_DEPENDS="clang, ncurses"
+TERMUX_PKG_DEPENDS="binutils, clang, iconv, libffi, llvm, ncurses"
+TERMUX_PKG_NO_STATICSPLIT=true
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS=" --disable-ld-override --build=x86_64-unknown-linux --host=x86_64-unknown-linux"
 
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS="--with-iconv-includes=$TERMUX_PREFIX/include -with-iconv-libraries=$TERMUX_PREFIX/lib"
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --with-curses-includes=$TERMUX_PREFIX/include/ncursesw -with-curses-libraries=$TERMUX_PREFIX/lib"
-TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --host=x86_64-unknown-linux --build=x86_64-unknown-linux"
+DYNAMIC_GHC_PROGRAMS=NO
 
-termux_step_post_extract_package() {
-	ORIG_CFLAGS="$CFLAGS"
-	ORIG_CPPFLAGS="$CPPFLAGS"
-	ORIG_LDFLAGS="$LDFLAGS"
+termux_step_pre_configure() {
+	TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --target=${TERMUX_HOST_PLATFORM}"
+
+	# After stage 0, cabal passes a host string to the libraries' configure scripts that isn't valid.
+	# We set one ourselves anyway, so this simply isn't needed.
+	sed -i 's/maybeHostFlag = i/maybeHostFlag = [] -- i/' libraries/Cabal/Cabal/Distribution/Simple.hs
+
+	# Android will only run PIE executables, so --no-pie, like GHC suggests, is out. GHC relies on relocations.
+	# Combine PIE and -Wl,-r together, and the linker will tell you those flags are mutually exclusive.
+	# This poses a problem as we need both. If you let the compiler handle it, then apparently all's well.
+	sed -i 's/"-Wl,-r"/"-r"/' compiler/main/DriverPipeline.hs
+
+	cp mk/build.mk.sample mk/build.mk
+	cat >> mk/build.mk <<-EOF
+	SRC_HC_OPTS     += -optc-Wno-unused-label -optc-Wno-unused-but-set-variable
+	SRC_HC_OPTS     += -optc-Wno-unused-variable -optc-Wno-unused-function
+	SRC_HC_OPTS     += -optc-Wno-unused-command-line-argument -optc-Wno-unknown-warning-option
+	GhcStage2HcOpts += -optl-Wl,--enable-new-dtags
+	INTEGER_LIBRARY = integer-simple
+	SplitSections   = YES
+	BuildFlavour         = perf-cross
+	HADDOCK_DOCS         = NO
+	BUILD_SPHINX_HTML    = NO
+	BUILD_SPHINX_PS      = NO
+	BUILD_SPHINX_PDF     = NO
+	DYNAMIC_GHC_PROGRAMS = $DYNAMIC_GHC_PROGRAMS
+	GhcLibWays = v
+	BUILD_MAN = NO
+	#STRIP_CMD = $STRIP
+	EOF
+	# If choosing to build a GHC dynamically linked to its libs, then
+	# $TERMUX_PREFIX/lib automatically gets added to the rpath that's generated
+	if [ "$DYNAMIC_GHC_PROGRAMS" != "YES" ]; then
+		echo "GhcStage2HcOpts += -optl-Wl,-rpath=$TERMUX_PREFIX/lib" >> mk/build.mk
+	fi
+
+# So... this is fun. If these options are initially passed to the configure script,
+# then building stage 0 breaks, because it's meant to run on the host with the
+# host's libs. But of course, we need to link to Termux's libffi etc. and use the
+# cross-compiler when building something to run on Android in the later stages
+patch -Np1 <<EOF
+--- a/rules/build-package-data.mk.orig	2020-06-09 23:44:52.013029077 +0000
++++ b/rules/build-package-data.mk	2020-06-09 23:45:10.589149807 +0000
+@@ -108,6 +108,15 @@
+ \$1_\$2_CONFIGURE_OPTS += --configure-option=--host=\$(TargetPlatformFull)
+ endif
+ 
++ifneq "\$3" "0"
++\$1_\$2_CONFIGURE_OPTS += --configure-option=--host=$TERMUX_HOST_PLATFORM --configure-option=CXX=$CXX --configure-option=LD=$LD --configure-option=AR=$AR
++\$1_\$2_CONFIGURE_OPTS += --configure-option=AS=$AS --configure-option=CC=$CC --configure-option=RANLIB=$RANLIB --configure-option=READELF=$READELF
++\$1_\$2_CONFIGURE_OPTS += --configure-option=OBJCOPY=$OBJCOPY --configure-option=OBJDUMP=$OBJDUMP --configure-option=--with-system-libffi
++\$1_\$2_CONFIGURE_OPTS += --configure-option=--with-ffi-includes=$TERMUX_PREFIX/include --configure-option=--with-ffi-libraries=$TERMUX_PREFIX/lib
++\$1_\$2_CONFIGURE_OPTS += --configure-option=--with-iconv-includes=$TERMUX_PREFIX/include --configure-option=--with-iconv-libraries=$TERMUX_PREFIX/lib
++\$1_\$2_CONFIGURE_OPTS += --configure-option=--with-curses-includes=$TERMUX_PREFIX/include/ncursesw --configure-option=--with-curses-libraries=$TERMUX_PREFIX/lib
++endif
++
+ ifeq "\$3" "0"
+ \$1_\$2_CONFIGURE_OPTS += \$\$(BOOT_PKG_CONSTRAINTS)
+ endif
+EOF
 
 	unset AR
 	unset AS
@@ -31,17 +84,65 @@ termux_step_post_extract_package() {
 	unset LD
 	unset PKG_CONFIG
 	unset RANLIB
+	unset READELF
+	unset OBJCOPY
+	unset OBJDUMP
 
-	TERMUX_PKG_EXTRA_CONFIGURE_ARGS+=" --target=${TERMUX_HOST_PLATFORM}"
+	autoreconf
 }
 
-termux_step_pre_configure() {
-	echo "INTEGER_LIBRARY = integer-simple" > mk/build.mk
-	#echo "GhcStage2HcOpts = $ORIG_CFLAGS $ORIG_CPPFLAGS $ORIG_LDFLAGS" >> mk/build.mk
+termux_step_post_make_install() {
+	# We may build GHC with `llc-9` etc., but only `llc` is present in Termux
+	sed -i 's/"LLVM llc command", "llc.*"/"LLVM llc command", "llc"/' "$TERMUX_PREFIX/lib/ghc-$TERMUX_PKG_VERSION/settings"
+	sed -i 's/"LLVM opt command", "opt.*"/"LLVM opt command", "opt"/' "$TERMUX_PREFIX/lib/ghc-$TERMUX_PKG_VERSION/settings"
 
-	# Avoid "Can't use -fPIC or -dynamic on this platform":
-	echo "DYNAMIC_GHC_PROGRAMS = NO" >> mk/build.mk
-	echo "GhcLibWays = v" >> mk/build.mk
-	# "Can not build haddock docs when CrossCompiling or Stage1Only".
-	echo "HADDOCK_DOCS=NO" >> mk/build.mk
+	if [ "$DYNAMIC_GHC_PROGRAMS" = "YES" ]; then
+		# Hack to turn the binaries' rpath from something relative to the build environment
+		# into something that matches Termux's FHS. patchelf needs to be installed on the host.
+		while IFS= read -r -d '' bin; do
+			local curr_rpath="$(patchelf --print-rpath "$bin" 2>/dev/null)"
+			if [ -n "$curr_rpath" ]; then
+				local paths_to_prepend=()
+				local new_rpath=()
+
+				IFS=':' read -ra paths <<< "$curr_rpath"
+				for i in "${!paths[@]}"; do
+					# Prioritise non-Haskell library paths
+					if [[ ${paths[$i]} != *ghc-$TERMUX_PKG_VERSION* ]]; then
+						paths_to_prepend+=("${paths[$i]}")
+						continue
+					fi
+					local fixed_path="${paths[$i]/\/dist-install\/build}"
+					if [ "$fixed_path" != "${paths[$i]}" ]; then
+						# Naïvely correct the path to a Haskell library
+						fixed_path="${fixed_path##*/}"
+						fixed_path=$(echo "$TERMUX_PREFIX/lib/ghc-$TERMUX_PKG_VERSION/$fixed_path-"[[:digit:]]*)
+						new_rpath+=("$fixed_path")
+					else
+						# This may be the path to RTS, which does not have a version number in the folder name
+						# and nor is it apparently expected to be found in dist-install
+						fixed_path="${paths[$i]/\/dist\/build}"
+						if [ "$fixed_path" != "${paths[$i]}" ]; then
+							new_rpath+=("$TERMUX_PREFIX/lib/ghc-$TERMUX_PKG_VERSION/${fixed_path##*/}")
+						else
+							new_rpath+=("$fixed_path")
+						fi
+					fi
+				done
+				# Make sure the standard Termux library path is the first entry
+				[[ ! " ${paths_to_prepend[@]} " =~ " $TERMUX_PREFIX/lib " ]] && paths_to_prepend=("$TERMUX_PREFIX/lib" "${paths_to_prepend[@]}")
+				# This isn't in the original rpath at all, but is needed
+				paths_to_prepend+=("$TERMUX_PREFIX/lib/ghc-$TERMUX_PKG_VERSION/ghc-$TERMUX_PKG_VERSION")
+				local OIFS="$IFS"
+				local IFS=':'
+				printf -v new_rpath "%s:%s" "${paths_to_prepend[*]}" "${new_rpath[*]}"
+				IFS="$OIFS"
+				patchelf --set-rpath "$new_rpath" "$bin"
+			fi
+		done < <(find "$TERMUX_PREFIX/lib/ghc-$TERMUX_PKG_VERSION/bin/" -type f -print0)
+	fi
+}
+
+termux_step_install_license() {
+	install -Dm600 -t "$TERMUX_PREFIX/share/doc/ghc" "$TERMUX_PKG_SRCDIR/LICENSE"
 }

--- a/packages/ghc/undefined_symbols.patch
+++ b/packages/ghc/undefined_symbols.patch
@@ -1,0 +1,24 @@
+--- ghc-8.10.1/rts/Trace.c	2020-03-24 04:53:17.000000000 +0000
++++ ghc-8.10.1.new/rts/Trace.c	2020-06-12 13:33:14.775373605 +0100
+@@ -12,6 +12,10 @@
+ // internal headers
+ #include "Trace.h"
+ 
++int TRACE_sched;
++int TRACE_gc;
++int TRACE_spark_sampled;
++
+ #if defined(TRACING)
+ 
+ #include "GetTime.h"
+@@ -28,10 +32,7 @@
+ #endif
+ 
+ // events
+-int TRACE_sched;
+-int TRACE_gc;
+ int TRACE_nonmoving_gc;
+-int TRACE_spark_sampled;
+ int TRACE_spark_full;
+ int TRACE_user;
+ int TRACE_cap;

--- a/packages/ghc/use-stage1-binaries-for-install.patch
+++ b/packages/ghc/use-stage1-binaries-for-install.patch
@@ -1,0 +1,28 @@
+Description: Use the stage1 binaries for install
+ In order to be able to perform a cross-build, we need to use
+ the stage1 binaries during installation. Both ghc and ghc-pkg
+ are run during the install target and therefore must be able
+ to run on the build machine.
+ .
+Author: John Paul Adrian Glaubitz <glaubitz@physik.fu-berlin.de>
+Last-Update: 2017-01-29
+
+Index: ghc-8.8.1+dfsg1/ghc.mk
+===================================================================
+--- ghc-8.8.1+dfsg1.orig/ghc.mk
++++ ghc-8.8.1+dfsg1/ghc.mk
+@@ -963,8 +963,12 @@
+ # Install packages in the right order, so that ghc-pkg doesn't complain.
+ # Also, install ghc-pkg first.
+ ifeq "$(Windows_Host)" "NO"
+-INSTALLED_GHC_REAL=$(DESTDIR)$(ghclibexecdir)/bin/ghc
+-INSTALLED_GHC_PKG_REAL=$(DESTDIR)$(ghclibexecdir)/bin/ghc-pkg
++# Use the inplace/stage1 versions for installation,
++# since the installed versions are built for the target
++#INSTALLED_GHC_REAL=$(DESTDIR)$(ghclibexecdir)/bin/ghc
++#INSTALLED_GHC_PKG_REAL=$(DESTDIR)$(ghclibexecdir)/bin/ghc-pkg
++INSTALLED_GHC_REAL=$(CURDIR)/inplace/bin/ghc-stage1
++INSTALLED_GHC_PKG_REAL=$(CURDIR)/utils/ghc-pkg/dist/build/tmp/ghc-pkg
+ else
+ INSTALLED_GHC_REAL=$(DESTDIR)$(bindir)/ghc.exe
+ INSTALLED_GHC_PKG_REAL=$(DESTDIR)$(bindir)/ghc-pkg.exe


### PR DESCRIPTION
This will fail to build. That's intentional: it gives you a chance to review this before large packages are added to the Docker container.

If this is deemed worthy for merging, I'd suggest the following:

```
diff --git a/scripts/setup-ubuntu.sh b/scripts/setup-ubuntu.sh
index ef49c9ca3..032054d36 100755
--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -137,6 +137,9 @@ PACKAGES+=" llvm-9-dev"
 PACKAGES+=" libparse-yapp-perl"
 PACKAGES+=" heimdal-multidev"
 PACKAGES+=" comerr-dev"
+PACKAGES+=" ghc"
+PACKAGES+=" alex"
+PACKAGES+=" happy"
 
 # Needed by packages in X11 repository.
 PACKAGES+=" docbook-xsl-ns"
```

* (Re)moving ghc from termux-packages/disabled-packages

Musings:

* This relies on the Ubuntu's host `ghc` to build stage 0. This means that updates to newer versions may not be possible until Ubuntu (well, Debian) updates their GHC. The GHC team somehow deemed Haskell popular enough to not provide a bootstrap compiler written in something that's not Haskell.

* I've not tested building for 32-bit ARM at all

* An AARCH64 build produces a 76 MiB deb file; the install takes up about 772 MB

* Inline patches in the build.sh may not be considered good practice. It is, however, the quickest way to do what I needed

* `ghc` doesn't understand `-Oz`. It may be possible to have `ghc` use `-O2` but have lld (or llc?) use `-Oz`, or maybe even `Os` works. But I decided against testing that because:

    * GHC is already slow on phones for anything larger than a "hello world" (although, TBH, this is more `llc` and `lld`'s fault)

    * Building `ghc` is a slow process on this laptop. As I've done it about 12 times already, I'm not really inclined to run through another test build

* While this package is configured to _not_ build a dynamic GHC, I've left in my horrible rpath hack to enable dynamically-built `ghc` and accompanying binaries to start if enabled. It needs patchelf installed on the host. I don't know Haskell, nor how its build process works, so I could only devise a way to fix things after the fact

    * Building a dynamic GHC means `ghci` (Haskell REPL) gets built too; however, the dynamic and static libraries together take up far too much space

    * If programs built with `ghc` are dynamically linked to the Haskell libraries, then upgrading ghc will most likely break them. Not worth the hassle, IMO

* I would have liked to have packaged cabal too, but that would mean creating a static binary with Ubuntu's 8.6.5 `ghc` and wrangling it to cross-compile a binary. I'll modify the Termux wiki with steps to build on device if that's OK. This also means that shellcheck cannot, sadly, be packaged either.

    * Shellcheck creates its official statically-linked ARM64 builds by cross-compiling the same version of GHC in the Debian repos, and then [symlinking the cross-compiled Haskell libs into the place the host `ghc` looks for them](https://github.com/koalaman/aarch64-builder/blob/master/Dockerfile#L18). Which I think is rather cool but I know that's understandably verboten by Termux packaging rules.

This works fine on my phone: I was able to build and run a simple "hello world", [something that uses the time library](http://lotz84.github.io/haskellbyexample/ex/time), [something that starts `ls`](https://lotz84.github.io/haskellbyexample/ex/spawning-processes) and [an FFI example](http://book.realworldhaskell.org/read/interfacing-with-c-the-ffi.html).